### PR TITLE
Fix channel number handling and add option to set channel-max.

### DIFF
--- a/client.go
+++ b/client.go
@@ -207,7 +207,7 @@ func (s *Session) NewReceiver(opts ...LinkOption) (*Receiver, error) {
 	// create dispositions channel and start dispositionBatcher if batching enabled
 	if r.batching {
 		// buffer dispositions chan to prevent disposition sends from blocking
-		r.dispositions = make(chan messageDisposition, l.linkCredit)
+		r.dispositions = make(chan messageDisposition, r.maxCredit)
 		go r.dispositionBatcher()
 	}
 


### PR DESCRIPTION
* Correctly record and use remote vs local channel. This worked with a
  single channel because both sides would pick zero and there would be
  no mismatch. When multiple channels were used frames from the second
  session could be delivered to the first.
* Added `ConnMaxSessions()` to allow adjustment of channel-max, which
  currently defaults to 65536.
* Does not currently support reusing sessions numbers after a session
  has been closed.
* Modified integration tests to allow testing multiple sessions.

Updates #6

Also including a data race fix I found while testing these changes.