### PR TITLE
Add SkipTLSNegotiation switch

### DIFF
--- a/client.go
+++ b/client.go
@@ -45,6 +45,7 @@ func Dial(addr string, opts ...ConnOption) (*Client, error) {
 		return nil, errorErrorf("unsupported scheme %q", u.Scheme)
 	}
 
+	debug(1, "dial %s", host+":"+port)
 	conn, err := net.Dial("tcp", host+":"+port)
 	if err != nil {
 		return nil, err

--- a/types.go
+++ b/types.go
@@ -145,6 +145,16 @@ const (
 	frameHeaderSize = 8
 )
 
+func newProtoHeader(pID protoID) *protoHeader {
+	return &protoHeader{
+		Proto:    [4]byte{'A', 'M', 'Q', 'P'},
+		ProtoID:  pID,
+		Major:    1,
+		Minor:    0,
+		Revision: 0,
+	}
+}
+
 // protoHeader in a structure appropriate for use with binary.Read()
 type protoHeader struct {
 	Proto    [4]byte
@@ -152,6 +162,23 @@ type protoHeader struct {
 	Major    uint8
 	Minor    uint8
 	Revision uint8
+}
+
+func (p *protoHeader) Bytes() []byte {
+	return []byte{
+		p.Proto[0],
+		p.Proto[1],
+		p.Proto[2],
+		p.Proto[3],
+		byte(p.ProtoID),
+		p.Major,
+		p.Minor,
+		p.Revision,
+	}
+}
+
+func (p *protoHeader) String() string {
+	return fmt.Sprintf("%s%%d%d.%d.%d.%d", p.Proto, p.ProtoID, p.Major, p.Minor, p.Revision)
 }
 
 // frame is the decoded representation of a frame


### PR DESCRIPTION
Hi there.
Ran into issue that some brokers expect connection previously TLS encrypted before SASL/AMQP negotiation.

https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-amqp-protocol-guide
> Azure Service Bus requires the use of TLS at all times. It supports connections over TCP port 5671, whereby the TCP connection is first overlaid with TLS before entering the AMQP protocol handshake, and also supports connections over TCP port 5672 whereby the server immediately offers a mandatory upgrade of connection to TLS using the AMQP-prescribed model. The AMQP WebSockets binding creates a tunnel over TCP port 443 that is then equivalent to AMQP 5671 connections.

But 5672 endpoint is missing for iothub AMQP brokers. 
Dug into existing iouthub SDKs and figured out that amqp library for nodejs doesn't even implement TLS negotiation at all (what I find very strange).

Made it work this way, any comment on this?