### PR TITLE
Fix map32 encoding

### DIFF
--- a/marshal_test.go
+++ b/marshal_test.go
@@ -362,6 +362,21 @@ var exampleTypes = []interface{}{
 			},
 		},
 	},
+	&performDetach{
+		Handle: 4352,
+		Closed: true,
+		Error: &Error{
+			Condition:   ErrorLinkRedirect,
+			Description: "",
+			// payload is bigger than map8 encoding size
+			Info: map[string]interface{}{
+				"hostname":     "redirected.myservicebus.example.org",
+				"network-host": "redirected.myservicebus.example.org",
+				"port":         5671,
+				"address":      "amqps://redirected.myservicebus.example.org:5671/path",
+			},
+		},
+	},
 	ErrorCondition("the condition"),
 	&Error{
 		Condition:   ErrorNotAllowed,

--- a/types.go
+++ b/types.go
@@ -581,7 +581,7 @@ func (u *unsettled) unmarshal(r reader) error {
 	}
 
 	m := make(unsettled, count/2)
-	for i := uint8(0); i < count; i += 2 {
+	for i := uint32(0); i < count; i += 2 {
 		key, err := readString(r)
 		if err != nil {
 			return err
@@ -2438,7 +2438,7 @@ func (m *mapAnyAny) unmarshal(r reader) error {
 	}
 
 	mm := make(mapAnyAny, count/2)
-	for i := uint8(0); i < count; i += 2 {
+	for i := uint32(0); i < count; i += 2 {
 		key, err := readAny(r)
 		if err != nil {
 			return err
@@ -2477,7 +2477,7 @@ func (m *mapStringAny) unmarshal(r reader) error {
 	}
 
 	mm := make(mapStringAny, count/2)
-	for i := uint8(0); i < count; i += 2 {
+	for i := uint32(0); i < count; i += 2 {
 		key, err := readString(r)
 		if err != nil {
 			return err
@@ -2507,7 +2507,7 @@ func (f *mapSymbolAny) unmarshal(r reader) error {
 	}
 
 	m := make(mapSymbolAny, count/2)
-	for i := uint8(0); i < count; i += 2 {
+	for i := uint32(0); i < count; i += 2 {
 		key, err := readString(r)
 		if err != nil {
 			return err


### PR DESCRIPTION
http://docs.oasis-open.org/amqp/core/v1.0/csprd01/amqp-core-types-v1.0-csprd01.html#type-map

Map parameters (size, count) have to be of the same size: 1 byte for map8 and 4 bytes for map32.
Right now count is always 1 byte.