### PR TITLE
Reduce marshal/unmarshal allocations

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -229,49 +229,60 @@ func writeInt32(wr writer, n int32) error {
 	return binaryWriteUint32(wr, uint32(n))
 }
 
-// tricky stuff to reduce allocations, do not modify without
-// benchmarking performance impact
-var (
-	poolByte2 = sync.Pool{
-		New: func() interface{} {
-			s := make([]byte, 2)
-			return &s
-		},
-	}
-	poolByte4 = sync.Pool{
-		New: func() interface{} {
-			s := make([]byte, 4)
-			return &s
-		},
-	}
-	poolByte8 = sync.Pool{
-		New: func() interface{} {
-			s := make([]byte, 8)
-			return &s
-		},
-	}
-)
-
 func binaryWriteUint16(wr writer, n uint16) error {
-	tmp := poolByte2.Get().(*[]byte)
-	binary.BigEndian.PutUint16(*tmp, n)
-	_, err := wr.Write(*tmp)
-	poolByte2.Put(tmp)
-	return err
+	err := wr.WriteByte(byte(n >> 8))
+	if err != nil {
+		return err
+	}
+	return wr.WriteByte(byte(n))
 }
+
 func binaryWriteUint32(wr writer, n uint32) error {
-	tmp := poolByte4.Get().(*[]byte)
-	binary.BigEndian.PutUint32(*tmp, n)
-	_, err := wr.Write(*tmp)
-	poolByte4.Put(tmp)
-	return err
+	err := wr.WriteByte(byte(n >> 24))
+	if err != nil {
+		return err
+	}
+	err = wr.WriteByte(byte(n >> 16))
+	if err != nil {
+		return err
+	}
+	err = wr.WriteByte(byte(n >> 8))
+	if err != nil {
+		return err
+	}
+	return wr.WriteByte(byte(n))
 }
+
 func binaryWriteUint64(wr writer, n uint64) error {
-	tmp := poolByte8.Get().(*[]byte)
-	binary.BigEndian.PutUint64(*tmp, n)
-	_, err := wr.Write(*tmp)
-	poolByte8.Put(tmp)
-	return err
+	err := wr.WriteByte(byte(n >> 56))
+	if err != nil {
+		return err
+	}
+	err = wr.WriteByte(byte(n >> 48))
+	if err != nil {
+		return err
+	}
+	err = wr.WriteByte(byte(n >> 40))
+	if err != nil {
+		return err
+	}
+	err = wr.WriteByte(byte(n >> 32))
+	if err != nil {
+		return err
+	}
+	err = wr.WriteByte(byte(n >> 24))
+	if err != nil {
+		return err
+	}
+	err = wr.WriteByte(byte(n >> 16))
+	if err != nil {
+		return err
+	}
+	err = wr.WriteByte(byte(n >> 8))
+	if err != nil {
+		return err
+	}
+	return wr.WriteByte(byte(n))
 }
 
 func writeInt64(wr writer, n int64) error {

--- a/encode.go
+++ b/encode.go
@@ -33,15 +33,20 @@ var bufPool = sync.Pool{
 
 // writesFrame encodes fr into buf.
 func writeFrame(buf *bytes.Buffer, fr frame) error {
-	header := frameHeader{
-		Size:       0, // overwrite later
-		DataOffset: 2, // see frameHeader.DataOffset comment
-		FrameType:  fr.typ,
-		Channel:    fr.channel,
-	}
-
 	// write header
-	err := binary.Write(buf, binary.BigEndian, header)
+	_, err := buf.Write([]byte{0, 0, 0, 0}) // size, overwrite later
+	if err != nil {
+		return err
+	}
+	err = buf.WriteByte(2) // doff, see frameHeader.DataOffset comment
+	if err != nil {
+		return err
+	}
+	err = buf.WriteByte(fr.typ) // frame type
+	if err != nil {
+		return err
+	}
+	err = binaryWriteUint16(buf, fr.channel) // channel
 	if err != nil {
 		return err
 	}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -16,326 +16,165 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestFraming(t *testing.T) {
-	t.Skip("TODO: add frame marshaling tests")
-	// frameHeader{},
-	// protoHeader{},
-	// frame{},
+var exampleFrames = []struct {
+	label string
+	frame frame
+}{
+	{
+		label: "transfer",
+		frame: frame{
+			typ:     frameTypeAMQP,
+			channel: 10,
+			body: &performTransfer{
+				Handle:             34983,
+				DeliveryID:         uint32Ptr(564),
+				DeliveryTag:        []byte("foo tag"),
+				MessageFormat:      uint32Ptr(34),
+				Settled:            true,
+				More:               true,
+				ReceiverSettleMode: rcvSettle(ModeSecond),
+				State:              &stateReceived{},
+				Resume:             true,
+				Aborted:            true,
+				Batchable:          true,
+				Payload:            []byte("very important payload"),
+			},
+		},
+	},
+}
+
+func TestFrameMarshalUnmarshal(t *testing.T) {
+	for _, tt := range exampleFrames {
+		t.Run(tt.label, func(t *testing.T) {
+			var buf bytes.Buffer
+
+			err := writeFrame(&buf, tt.frame)
+			if err != nil {
+				t.Error(fmt.Sprintf("%+v", err))
+			}
+
+			header, err := parseFrameHeader(&buf)
+			if err != nil {
+				t.Errorf("%+v", err)
+			}
+
+			want := tt.frame
+			if header.Channel != want.channel {
+				t.Errorf("Expected channel to be %d, but it is %d", want.channel, header.Channel)
+			}
+			if header.FrameType != want.typ {
+				t.Errorf("Expected channel to be %d, but it is %d", want.typ, header.FrameType)
+			}
+
+			payload, err := parseFrameBody(&buf)
+			cmpOpts := cmp.Options{
+				DeepAllowUnexported(want.body, payload),
+			}
+			if !cmp.Equal(want.body, payload, cmpOpts...) {
+				t.Errorf("Roundtrip produced different results:\n %s", cmp.Diff(want.body, payload, cmpOpts...))
+			}
+		})
+	}
+}
+
+func BenchmarkFrameMarshal(b *testing.B) {
+	for _, tt := range exampleFrames {
+		b.Run(tt.label, func(b *testing.B) {
+			b.ReportAllocs()
+			var buf bytes.Buffer
+
+			for i := 0; i < b.N; i++ {
+				err := writeFrame(&buf, tt.frame)
+				if err != nil {
+					b.Error(fmt.Sprintf("%+v", err))
+				}
+				bytesSink = buf.Bytes()
+				buf.Reset()
+			}
+		})
+	}
+}
+func BenchmarkFrameUnmarshal(b *testing.B) {
+	for _, tt := range exampleFrames {
+		b.Run(tt.label, func(b *testing.B) {
+			b.ReportAllocs()
+			var buf bytes.Buffer
+			err := writeFrame(&buf, tt.frame)
+			if err != nil {
+				b.Error(fmt.Sprintf("%+v", err))
+			}
+			data := buf.Bytes()
+			buf.Reset()
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				buf := bytes.NewBuffer(data)
+				_, err := parseFrameHeader(buf)
+				if err != nil {
+					b.Errorf("%+v", err)
+				}
+
+				_, err = parseFrameBody(buf)
+				if err != nil {
+					b.Errorf("%+v", err)
+				}
+			}
+		})
+	}
+}
+
+var bytesSink []byte
+
+func BenchmarkMarshal(b *testing.B) {
+	for _, typ := range exampleTypes {
+		b.Run(fmt.Sprintf("%T", typ), func(b *testing.B) {
+			b.ReportAllocs()
+			var buf bytes.Buffer
+
+			for i := 0; i < b.N; i++ {
+				err := marshal(&buf, typ)
+				if err != nil {
+					b.Error(fmt.Sprintf("%+v", err))
+				}
+				bytesSink = buf.Bytes()
+				buf.Reset()
+			}
+		})
+	}
+}
+
+var typeSink interface{}
+
+func BenchmarkUnmarshal(b *testing.B) {
+	for _, typ := range exampleTypes {
+		b.Run(fmt.Sprintf("%T", typ), func(b *testing.B) {
+			var buf bytes.Buffer
+			err := marshal(&buf, typ)
+			if err != nil {
+				b.Error(fmt.Sprintf("%+v", err))
+			}
+			data := buf.Bytes()
+			newTyp := reflect.New(reflect.TypeOf(typ)).Interface()
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				typeSink, err = unmarshal(bytes.NewBuffer(data), newTyp)
+				if err != nil {
+					b.Error(fmt.Sprintf("%v", err))
+				}
+			}
+		})
+	}
 }
 
 func TestMarshalUnmarshal(t *testing.T) {
 	_, updateFuzzCorpus := os.LookupEnv("UPDATE_FUZZ_CORPUS")
 
-	types := []interface{}{
-		&performOpen{
-			ContainerID:         "foo",
-			Hostname:            "bar.host",
-			MaxFrameSize:        4200,
-			ChannelMax:          13,
-			OutgoingLocales:     []symbol{"fooLocale"},
-			IncomingLocales:     []symbol{"barLocale"},
-			OfferedCapabilities: []symbol{"fooCap"},
-			DesiredCapabilities: []symbol{"barCap"},
-			Properties: map[symbol]interface{}{
-				"fooProp": 45,
-			},
-		},
-		&performBegin{
-			RemoteChannel:       4321,
-			NextOutgoingID:      730000,
-			IncomingWindow:      9876654,
-			OutgoingWindow:      123555,
-			HandleMax:           9757,
-			OfferedCapabilities: []symbol{"fooCap"},
-			DesiredCapabilities: []symbol{"barCap"},
-			Properties: map[symbol]interface{}{
-				"fooProp": 45,
-			},
-		},
-		&performAttach{
-			Name:               "fooName",
-			Handle:             435982,
-			Role:               roleSender,
-			SenderSettleMode:   sndSettle(ModeMixed),
-			ReceiverSettleMode: rcvSettle(ModeSecond),
-			Source: &source{
-				Address:      "fooAddr",
-				Durable:      2,
-				ExpiryPolicy: "link-detach",
-				Timeout:      635,
-				Dynamic:      true,
-				DynamicNodeProperties: map[symbol]interface{}{
-					"lifetime-policy": deleteOnClose,
-				},
-				DistributionMode: "some-mode",
-				Filter: map[symbol]interface{}{
-					"foo:filter": "bar value",
-				},
-				Outcomes:     []symbol{"amqp:accepted:list"},
-				Capabilities: []symbol{"barCap"},
-			},
-			Target: &target{
-				Address:      "fooAddr",
-				Durable:      2,
-				ExpiryPolicy: "link-detach",
-				Timeout:      635,
-				Dynamic:      true,
-				DynamicNodeProperties: map[symbol]interface{}{
-					"lifetime-policy": deleteOnClose,
-				},
-				Capabilities: []symbol{"barCap"},
-			},
-			Unsettled: unsettled{
-				"fooDeliveryTag": &stateAccepted{},
-			},
-			IncompleteUnsettled:  true,
-			InitialDeliveryCount: 3184,
-			MaxMessageSize:       75983,
-			OfferedCapabilities:  []symbol{"fooCap"},
-			DesiredCapabilities:  []symbol{"barCap"},
-			Properties: map[symbol]interface{}{
-				"fooProp": 45,
-			},
-		},
-		role(true),
-		&unsettled{
-			"fooDeliveryTag": &stateAccepted{},
-		},
-		&source{
-			Address:      "fooAddr",
-			Durable:      2,
-			ExpiryPolicy: "link-detach",
-			Timeout:      635,
-			Dynamic:      true,
-			DynamicNodeProperties: map[symbol]interface{}{
-				"lifetime-policy": deleteOnClose,
-			},
-			DistributionMode: "some-mode",
-			Filter: map[symbol]interface{}{
-				"foo:filter": "bar value",
-			},
-			Outcomes:     []symbol{"amqp:accepted:list"},
-			Capabilities: []symbol{"barCap"},
-		},
-		&target{
-			Address:      "fooAddr",
-			Durable:      2,
-			ExpiryPolicy: "link-detach",
-			Timeout:      635,
-			Dynamic:      true,
-			DynamicNodeProperties: map[symbol]interface{}{
-				"lifetime-policy": deleteOnClose,
-			},
-			Capabilities: []symbol{"barCap"},
-		},
-		&performFlow{
-			NextIncomingID: uint32Ptr(354),
-			IncomingWindow: 4352,
-			NextOutgoingID: 85324,
-			OutgoingWindow: 24378634,
-			Handle:         uint32Ptr(341543),
-			DeliveryCount:  uint32Ptr(31341),
-			LinkCredit:     uint32Ptr(7634),
-			Available:      uint32Ptr(878321),
-			Drain:          true,
-			Echo:           true,
-			Properties: map[symbol]interface{}{
-				"fooProp": 45,
-			},
-		},
-		&performTransfer{
-			Handle:             34983,
-			DeliveryID:         uint32Ptr(564),
-			DeliveryTag:        []byte("foo tag"),
-			MessageFormat:      uint32Ptr(34),
-			Settled:            true,
-			More:               true,
-			ReceiverSettleMode: rcvSettle(ModeSecond),
-			State:              &stateReceived{},
-			Resume:             true,
-			Aborted:            true,
-			Batchable:          true,
-			Payload:            []byte("very important payload"),
-		},
-		&performDisposition{
-			Role:      roleSender,
-			First:     5644444,
-			Last:      uint32Ptr(423),
-			Settled:   true,
-			State:     &stateReleased{},
-			Batchable: true,
-		},
-		&performDetach{
-			Handle: 4352,
-			Closed: true,
-			Error: &Error{
-				Condition:   ErrorNotAllowed,
-				Description: "foo description",
-				Info: map[string]interface{}{
-					"other": "info",
-					"and":   875,
-				},
-			},
-		},
-		ErrorCondition("the condition"),
-		&Error{
-			Condition:   ErrorNotAllowed,
-			Description: "foo description",
-			Info: map[string]interface{}{
-				"other": "info",
-				"and":   875,
-			},
-		},
-		&performEnd{
-			Error: &Error{
-				Condition:   ErrorNotAllowed,
-				Description: "foo description",
-				Info: map[string]interface{}{
-					"other": "info",
-					"and":   875,
-				},
-			},
-		},
-		&performClose{
-			Error: &Error{
-				Condition:   ErrorNotAllowed,
-				Description: "foo description",
-				Info: map[string]interface{}{
-					"other": "info",
-					"and":   875,
-				},
-			},
-		},
-		&Message{
-			Header: &MessageHeader{
-				Durable:       true,
-				Priority:      234,
-				TTL:           10 * time.Second,
-				FirstAcquirer: true,
-				DeliveryCount: 32,
-			},
-			DeliveryAnnotations: map[interface{}]interface{}{
-				42: "answer",
-			},
-			Annotations: map[interface{}]interface{}{
-				42: "answer",
-			},
-			Properties: &MessageProperties{
-				MessageID:          "yo",
-				UserID:             []byte("baz"),
-				To:                 "me",
-				Subject:            "sup?",
-				ReplyTo:            "you",
-				CorrelationID:      34513,
-				ContentType:        "text/plain",
-				ContentEncoding:    "UTF-8",
-				AbsoluteExpiryTime: time.Date(2018, 01, 13, 14, 24, 07, 0, time.UTC),
-				CreationTime:       time.Date(2018, 01, 13, 14, 14, 07, 0, time.UTC),
-				GroupID:            "fooGroup",
-				GroupSequence:      89324,
-				ReplyToGroupID:     "barGroup",
-			},
-			ApplicationProperties: map[string]interface{}{
-				"baz": "foo",
-			},
-			Data:  []byte("A nice little data payload."),
-			Value: 42,
-			Footer: map[interface{}]interface{}{
-				"hash": []uint8{0, 1, 2, 34, 5, 6, 7, 8, 9, 0},
-			},
-		},
-		&MessageHeader{
-			Durable:       true,
-			Priority:      234,
-			TTL:           10 * time.Second,
-			FirstAcquirer: true,
-			DeliveryCount: 32,
-		},
-		&MessageProperties{
-			MessageID:          "yo",
-			UserID:             []byte("baz"),
-			To:                 "me",
-			Subject:            "sup?",
-			ReplyTo:            "you",
-			CorrelationID:      34513,
-			ContentType:        "text/plain",
-			ContentEncoding:    "UTF-8",
-			AbsoluteExpiryTime: time.Date(2018, 01, 13, 14, 24, 07, 0, time.UTC),
-			CreationTime:       time.Date(2018, 01, 13, 14, 14, 07, 0, time.UTC),
-			GroupID:            "fooGroup",
-			GroupSequence:      89324,
-			ReplyToGroupID:     "barGroup",
-		},
-		&stateReceived{
-			SectionNumber: 234,
-			SectionOffset: 8973,
-		},
-		&stateAccepted{},
-		&stateRejected{
-			Error: &Error{
-				Condition:   ErrorStolen,
-				Description: "foo description",
-				Info: map[string]interface{}{
-					"other": "info",
-					"and":   875,
-				},
-			},
-		},
-		&stateReleased{},
-		&stateModified{
-			DeliveryFailed:    true,
-			UndeliverableHere: true,
-			MessageAnnotations: map[symbol]interface{}{
-				"more": "annotations",
-			},
-		},
-		&saslInit{
-			Mechanism:       "FOO",
-			InitialResponse: []byte("BAR\x00RESPONSE\x00"),
-			Hostname:        "me",
-		},
-		&saslMechanisms{
-			Mechanisms: []symbol{"FOO", "BAR", "BAZ"},
-		},
-		&saslOutcome{
-			Code:           codeSASLSysPerm,
-			AdditionalData: []byte("here's some info for you..."),
-		},
-		symbol("a symbol"),
-		milliseconds(10 * time.Second),
-		&mapAnyAny{
-			-1234: []uint8{0, 1, 2, 34, 5, 6, 7, 8, 9, 0},
-		},
-		&mapStringAny{
-			"hash": []uint8{0, 1, 2, 34, 5, 6, 7, 8, 9, 0},
-		},
-		&mapSymbolAny{
-			"hash": []uint8{0, 1, 2, 34, 5, 6, 7, 8, 9, 0},
-		},
-		UUID{1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 14, 15, 16},
-		lifetimePolicy(typeCodeDeleteOnClose),
-		SenderSettleMode(1),
-		ReceiverSettleMode(1),
-		bool(true),
-		int8(math.MaxInt8),
-		int8(math.MinInt8),
-		int16(math.MaxInt16),
-		int16(math.MinInt16),
-		int32(math.MaxInt32),
-		int32(math.MinInt32),
-		int64(math.MaxInt64),
-		int64(math.MinInt64),
-		uint8(math.MaxUint8),
-		uint16(math.MaxUint16),
-		uint32(math.MaxUint32),
-		uint64(math.MaxUint64),
-		describedType{
-			descriptor: binary.BigEndian.Uint64([]byte{0x00, 0x00, 0x46, 0x8C, 0x00, 0x00, 0x00, 0x04}),
-			value:      "amqp.annotation.x-opt-offset > '312'",
-		},
-	}
-
-	for _, typ := range types {
+	for _, typ := range exampleTypes {
 		t.Run(fmt.Sprintf("%T", typ), func(t *testing.T) {
 			var buf bytes.Buffer
 			err := marshal(&buf, typ)
@@ -370,6 +209,315 @@ func TestMarshalUnmarshal(t *testing.T) {
 			}
 		})
 	}
+}
+
+var exampleTypes = []interface{}{
+	&performOpen{
+		ContainerID:         "foo",
+		Hostname:            "bar.host",
+		MaxFrameSize:        4200,
+		ChannelMax:          13,
+		OutgoingLocales:     []symbol{"fooLocale"},
+		IncomingLocales:     []symbol{"barLocale"},
+		OfferedCapabilities: []symbol{"fooCap"},
+		DesiredCapabilities: []symbol{"barCap"},
+		Properties: map[symbol]interface{}{
+			"fooProp": 45,
+		},
+	},
+	&performBegin{
+		RemoteChannel:       4321,
+		NextOutgoingID:      730000,
+		IncomingWindow:      9876654,
+		OutgoingWindow:      123555,
+		HandleMax:           9757,
+		OfferedCapabilities: []symbol{"fooCap"},
+		DesiredCapabilities: []symbol{"barCap"},
+		Properties: map[symbol]interface{}{
+			"fooProp": 45,
+		},
+	},
+	&performAttach{
+		Name:               "fooName",
+		Handle:             435982,
+		Role:               roleSender,
+		SenderSettleMode:   sndSettle(ModeMixed),
+		ReceiverSettleMode: rcvSettle(ModeSecond),
+		Source: &source{
+			Address:      "fooAddr",
+			Durable:      2,
+			ExpiryPolicy: "link-detach",
+			Timeout:      635,
+			Dynamic:      true,
+			DynamicNodeProperties: map[symbol]interface{}{
+				"lifetime-policy": deleteOnClose,
+			},
+			DistributionMode: "some-mode",
+			Filter: map[symbol]interface{}{
+				"foo:filter": "bar value",
+			},
+			Outcomes:     []symbol{"amqp:accepted:list"},
+			Capabilities: []symbol{"barCap"},
+		},
+		Target: &target{
+			Address:      "fooAddr",
+			Durable:      2,
+			ExpiryPolicy: "link-detach",
+			Timeout:      635,
+			Dynamic:      true,
+			DynamicNodeProperties: map[symbol]interface{}{
+				"lifetime-policy": deleteOnClose,
+			},
+			Capabilities: []symbol{"barCap"},
+		},
+		Unsettled: unsettled{
+			"fooDeliveryTag": &stateAccepted{},
+		},
+		IncompleteUnsettled:  true,
+		InitialDeliveryCount: 3184,
+		MaxMessageSize:       75983,
+		OfferedCapabilities:  []symbol{"fooCap"},
+		DesiredCapabilities:  []symbol{"barCap"},
+		Properties: map[symbol]interface{}{
+			"fooProp": 45,
+		},
+	},
+	role(true),
+	&unsettled{
+		"fooDeliveryTag": &stateAccepted{},
+	},
+	&source{
+		Address:      "fooAddr",
+		Durable:      2,
+		ExpiryPolicy: "link-detach",
+		Timeout:      635,
+		Dynamic:      true,
+		DynamicNodeProperties: map[symbol]interface{}{
+			"lifetime-policy": deleteOnClose,
+		},
+		DistributionMode: "some-mode",
+		Filter: map[symbol]interface{}{
+			"foo:filter": "bar value",
+		},
+		Outcomes:     []symbol{"amqp:accepted:list"},
+		Capabilities: []symbol{"barCap"},
+	},
+	&target{
+		Address:      "fooAddr",
+		Durable:      2,
+		ExpiryPolicy: "link-detach",
+		Timeout:      635,
+		Dynamic:      true,
+		DynamicNodeProperties: map[symbol]interface{}{
+			"lifetime-policy": deleteOnClose,
+		},
+		Capabilities: []symbol{"barCap"},
+	},
+	&performFlow{
+		NextIncomingID: uint32Ptr(354),
+		IncomingWindow: 4352,
+		NextOutgoingID: 85324,
+		OutgoingWindow: 24378634,
+		Handle:         uint32Ptr(341543),
+		DeliveryCount:  uint32Ptr(31341),
+		LinkCredit:     uint32Ptr(7634),
+		Available:      uint32Ptr(878321),
+		Drain:          true,
+		Echo:           true,
+		Properties: map[symbol]interface{}{
+			"fooProp": 45,
+		},
+	},
+	&performTransfer{
+		Handle:             34983,
+		DeliveryID:         uint32Ptr(564),
+		DeliveryTag:        []byte("foo tag"),
+		MessageFormat:      uint32Ptr(34),
+		Settled:            true,
+		More:               true,
+		ReceiverSettleMode: rcvSettle(ModeSecond),
+		State:              &stateReceived{},
+		Resume:             true,
+		Aborted:            true,
+		Batchable:          true,
+		Payload:            []byte("very important payload"),
+	},
+	&performDisposition{
+		Role:      roleSender,
+		First:     5644444,
+		Last:      uint32Ptr(423),
+		Settled:   true,
+		State:     &stateReleased{},
+		Batchable: true,
+	},
+	&performDetach{
+		Handle: 4352,
+		Closed: true,
+		Error: &Error{
+			Condition:   ErrorNotAllowed,
+			Description: "foo description",
+			Info: map[string]interface{}{
+				"other": "info",
+				"and":   875,
+			},
+		},
+	},
+	ErrorCondition("the condition"),
+	&Error{
+		Condition:   ErrorNotAllowed,
+		Description: "foo description",
+		Info: map[string]interface{}{
+			"other": "info",
+			"and":   875,
+		},
+	},
+	&performEnd{
+		Error: &Error{
+			Condition:   ErrorNotAllowed,
+			Description: "foo description",
+			Info: map[string]interface{}{
+				"other": "info",
+				"and":   875,
+			},
+		},
+	},
+	&performClose{
+		Error: &Error{
+			Condition:   ErrorNotAllowed,
+			Description: "foo description",
+			Info: map[string]interface{}{
+				"other": "info",
+				"and":   875,
+			},
+		},
+	},
+	&Message{
+		Header: &MessageHeader{
+			Durable:       true,
+			Priority:      234,
+			TTL:           10 * time.Second,
+			FirstAcquirer: true,
+			DeliveryCount: 32,
+		},
+		DeliveryAnnotations: map[interface{}]interface{}{
+			42: "answer",
+		},
+		Annotations: map[interface{}]interface{}{
+			42: "answer",
+		},
+		Properties: &MessageProperties{
+			MessageID:          "yo",
+			UserID:             []byte("baz"),
+			To:                 "me",
+			Subject:            "sup?",
+			ReplyTo:            "you",
+			CorrelationID:      34513,
+			ContentType:        "text/plain",
+			ContentEncoding:    "UTF-8",
+			AbsoluteExpiryTime: time.Date(2018, 01, 13, 14, 24, 07, 0, time.UTC),
+			CreationTime:       time.Date(2018, 01, 13, 14, 14, 07, 0, time.UTC),
+			GroupID:            "fooGroup",
+			GroupSequence:      89324,
+			ReplyToGroupID:     "barGroup",
+		},
+		ApplicationProperties: map[string]interface{}{
+			"baz": "foo",
+		},
+		Data:  []byte("A nice little data payload."),
+		Value: 42,
+		Footer: map[interface{}]interface{}{
+			"hash": []uint8{0, 1, 2, 34, 5, 6, 7, 8, 9, 0},
+		},
+	},
+	&MessageHeader{
+		Durable:       true,
+		Priority:      234,
+		TTL:           10 * time.Second,
+		FirstAcquirer: true,
+		DeliveryCount: 32,
+	},
+	&MessageProperties{
+		MessageID:          "yo",
+		UserID:             []byte("baz"),
+		To:                 "me",
+		Subject:            "sup?",
+		ReplyTo:            "you",
+		CorrelationID:      34513,
+		ContentType:        "text/plain",
+		ContentEncoding:    "UTF-8",
+		AbsoluteExpiryTime: time.Date(2018, 01, 13, 14, 24, 07, 0, time.UTC),
+		CreationTime:       time.Date(2018, 01, 13, 14, 14, 07, 0, time.UTC),
+		GroupID:            "fooGroup",
+		GroupSequence:      89324,
+		ReplyToGroupID:     "barGroup",
+	},
+	&stateReceived{
+		SectionNumber: 234,
+		SectionOffset: 8973,
+	},
+	&stateAccepted{},
+	&stateRejected{
+		Error: &Error{
+			Condition:   ErrorStolen,
+			Description: "foo description",
+			Info: map[string]interface{}{
+				"other": "info",
+				"and":   875,
+			},
+		},
+	},
+	&stateReleased{},
+	&stateModified{
+		DeliveryFailed:    true,
+		UndeliverableHere: true,
+		MessageAnnotations: map[symbol]interface{}{
+			"more": "annotations",
+		},
+	},
+	UUID{1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 14, 15, 16},
+	lifetimePolicy(typeCodeDeleteOnClose),
+	SenderSettleMode(1),
+	ReceiverSettleMode(1),
+	bool(true),
+	int8(math.MaxInt8),
+	int8(math.MinInt8),
+	int16(math.MaxInt16),
+	int16(math.MinInt16),
+	int32(math.MaxInt32),
+	int32(math.MinInt32),
+	int64(math.MaxInt64),
+	int64(math.MinInt64),
+	uint8(math.MaxUint8),
+	uint16(math.MaxUint16),
+	uint32(math.MaxUint32),
+	uint64(math.MaxUint64),
+	describedType{
+		descriptor: binary.BigEndian.Uint64([]byte{0x00, 0x00, 0x46, 0x8C, 0x00, 0x00, 0x00, 0x04}),
+		value:      "amqp.annotation.x-opt-offset > '312'",
+	},
+	&saslInit{
+		Mechanism:       "FOO",
+		InitialResponse: []byte("BAR\x00RESPONSE\x00"),
+		Hostname:        "me",
+	},
+	&saslMechanisms{
+		Mechanisms: []symbol{"FOO", "BAR", "BAZ"},
+	},
+	&saslOutcome{
+		Code:           codeSASLSysPerm,
+		AdditionalData: []byte("here's some info for you..."),
+	},
+	symbol("a symbol"),
+	milliseconds(10 * time.Second),
+	&mapAnyAny{
+		-1234: []uint8{0, 1, 2, 34, 5, 6, 7, 8, 9, 0},
+	},
+	&mapStringAny{
+		"hash": []uint8{0, 1, 2, 34, 5, 6, 7, 8, 9, 0},
+	},
+	&mapSymbolAny{
+		"hash": []uint8{0, 1, 2, 34, 5, 6, 7, 8, 9, 0},
+	},
 }
 
 func sndSettle(m SenderSettleMode) *SenderSettleMode {

--- a/types.go
+++ b/types.go
@@ -1,7 +1,6 @@
 package amqp
 
 import (
-	"bytes"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
@@ -1900,7 +1899,7 @@ func peekMessageType(buf []byte) (uint8, error) {
 		return 0, errorErrorf("invalid composite header %0x", buf[0])
 	}
 
-	v, err := readInt(bytes.NewBuffer(buf[1:]))
+	v, err := readUlong(&roReader{b: buf[1:]})
 	if err != nil {
 		return 0, err
 	}

--- a/types.go
+++ b/types.go
@@ -2319,10 +2319,7 @@ func (n amqpUint16) marshal(wr writer) error {
 	if err != nil {
 		return err
 	}
-	tmp := make([]byte, 2)
-	binary.BigEndian.PutUint16(tmp, uint16(n))
-	_, err = wr.Write(tmp)
-	return err
+	return binaryWriteUint16(wr, uint16(n))
 }
 
 type amqpUint32 uint32
@@ -2361,9 +2358,7 @@ func (s amqpString) marshal(wr writer) error {
 			return err
 		}
 
-		tmp := make([]byte, 4)
-		binary.BigEndian.PutUint32(tmp, uint32(l))
-		_, err = wr.Write(tmp)
+		err = binaryWriteUint32(wr, uint32(l))
 		if err != nil {
 			return err
 		}
@@ -2402,12 +2397,12 @@ func (s symbol) marshal(wr writer) error {
 		if err != nil {
 			return err
 		}
-		tmp := make([]byte, 4)
-		binary.BigEndian.PutUint32(tmp, uint32(l))
-		_, err := wr.Write(tmp)
+
+		err = binaryWriteUint32(wr, uint32(l))
 		if err != nil {
 			return err
 		}
+
 		_, err = wr.WriteString(string(s))
 	default:
 		return errorNew("too long")

--- a/types.go
+++ b/types.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"strconv"
 	"time"
+	"unicode/utf8"
 )
 
 type amqpType uint8
@@ -205,15 +206,15 @@ func (o *performOpen) link() (uint32, bool) {
 
 func (o *performOpen) marshal(wr writer) error {
 	return marshalComposite(wr, typeCodeOpen, []marshalField{
-		{value: o.ContainerID, omit: false},
-		{value: o.Hostname, omit: o.Hostname == ""},
-		{value: o.MaxFrameSize, omit: o.MaxFrameSize == 0},
-		{value: o.ChannelMax, omit: o.ChannelMax == 0},
-		{value: milliseconds(o.IdleTimeout), omit: o.IdleTimeout == 0},
-		{value: o.OutgoingLocales, omit: len(o.OutgoingLocales) == 0},
-		{value: o.IncomingLocales, omit: len(o.IncomingLocales) == 0},
-		{value: o.OfferedCapabilities, omit: len(o.OfferedCapabilities) == 0},
-		{value: o.DesiredCapabilities, omit: len(o.DesiredCapabilities) == 0},
+		{value: &o.ContainerID, omit: false},
+		{value: &o.Hostname, omit: o.Hostname == ""},
+		{value: &o.MaxFrameSize, omit: o.MaxFrameSize == 0},
+		{value: &o.ChannelMax, omit: o.ChannelMax == 0},
+		{value: (*milliseconds)(&o.IdleTimeout), omit: o.IdleTimeout == 0},
+		{value: &o.OutgoingLocales, omit: len(o.OutgoingLocales) == 0},
+		{value: &o.IncomingLocales, omit: len(o.IncomingLocales) == 0},
+		{value: &o.OfferedCapabilities, omit: len(o.OfferedCapabilities) == 0},
+		{value: &o.DesiredCapabilities, omit: len(o.DesiredCapabilities) == 0},
 		{value: o.Properties, omit: len(o.Properties) == 0},
 	}...)
 }
@@ -305,13 +306,13 @@ func (b *performBegin) link() (uint32, bool) {
 
 func (b *performBegin) marshal(wr writer) error {
 	return marshalComposite(wr, typeCodeBegin, []marshalField{
-		{value: b.RemoteChannel, omit: b.RemoteChannel == 0},
-		{value: b.NextOutgoingID, omit: false},
-		{value: b.IncomingWindow, omit: false},
-		{value: b.OutgoingWindow, omit: false},
-		{value: b.HandleMax, omit: b.HandleMax == 0},
-		{value: b.OfferedCapabilities, omit: len(b.OfferedCapabilities) == 0},
-		{value: b.DesiredCapabilities, omit: len(b.DesiredCapabilities) == 0},
+		{value: &b.RemoteChannel, omit: b.RemoteChannel == 0},
+		{value: &b.NextOutgoingID, omit: false},
+		{value: &b.IncomingWindow, omit: false},
+		{value: &b.OutgoingWindow, omit: false},
+		{value: &b.HandleMax, omit: b.HandleMax == 0},
+		{value: &b.OfferedCapabilities, omit: len(b.OfferedCapabilities) == 0},
+		{value: &b.DesiredCapabilities, omit: len(b.DesiredCapabilities) == 0},
 		{value: b.Properties, omit: b.Properties == nil},
 	}...)
 }
@@ -319,10 +320,10 @@ func (b *performBegin) marshal(wr writer) error {
 func (b *performBegin) unmarshal(r reader) error {
 	return unmarshalComposite(r, typeCodeBegin, []unmarshalField{
 		{field: &b.RemoteChannel},
-		{field: &b.NextOutgoingID, handleNull: required("Begin.NextOutgoingID")},
-		{field: &b.IncomingWindow, handleNull: required("Begin.IncomingWindow")},
-		{field: &b.OutgoingWindow, handleNull: required("Begin.OutgoingWindow")},
-		{field: &b.HandleMax, handleNull: defaultUint32(&b.HandleMax, 4294967295)},
+		{field: &b.NextOutgoingID, handleNull: func() error { return errorNew("Begin.NextOutgoingID is required") }},
+		{field: &b.IncomingWindow, handleNull: func() error { return errorNew("Begin.IncomingWindow is required") }},
+		{field: &b.OutgoingWindow, handleNull: func() error { return errorNew("Begin.OutgoingWindow is required") }},
+		{field: &b.HandleMax, handleNull: func() error { b.HandleMax = 4294967295; return nil }},
 		{field: &b.OfferedCapabilities},
 		{field: &b.DesiredCapabilities},
 		{field: &b.Properties},
@@ -506,28 +507,28 @@ func (a *performAttach) link() (uint32, bool) {
 
 func (a *performAttach) marshal(wr writer) error {
 	return marshalComposite(wr, typeCodeAttach, []marshalField{
-		{value: a.Name, omit: false},
-		{value: a.Handle, omit: false},
-		{value: a.Role, omit: false},
+		{value: &a.Name, omit: false},
+		{value: &a.Handle, omit: false},
+		{value: &a.Role, omit: false},
 		{value: a.SenderSettleMode, omit: a.SenderSettleMode == nil},
 		{value: a.ReceiverSettleMode, omit: a.ReceiverSettleMode == nil},
 		{value: a.Source, omit: a.Source == nil},
 		{value: a.Target, omit: a.Target == nil},
 		{value: a.Unsettled, omit: len(a.Unsettled) == 0},
-		{value: a.IncompleteUnsettled, omit: !a.IncompleteUnsettled},
-		{value: a.InitialDeliveryCount, omit: a.Role == roleReceiver},
-		{value: a.MaxMessageSize, omit: a.MaxMessageSize == 0},
-		{value: a.OfferedCapabilities, omit: len(a.OfferedCapabilities) == 0},
-		{value: a.DesiredCapabilities, omit: len(a.DesiredCapabilities) == 0},
+		{value: &a.IncompleteUnsettled, omit: !a.IncompleteUnsettled},
+		{value: &a.InitialDeliveryCount, omit: a.Role == roleReceiver},
+		{value: &a.MaxMessageSize, omit: a.MaxMessageSize == 0},
+		{value: &a.OfferedCapabilities, omit: len(a.OfferedCapabilities) == 0},
+		{value: &a.DesiredCapabilities, omit: len(a.DesiredCapabilities) == 0},
 		{value: a.Properties, omit: len(a.Properties) == 0},
 	}...)
 }
 
 func (a *performAttach) unmarshal(r reader) error {
 	return unmarshalComposite(r, typeCodeAttach, []unmarshalField{
-		{field: &a.Name, handleNull: required("Attach.Name")},
-		{field: &a.Handle, handleNull: required("Attach.Handle")},
-		{field: &a.Role, handleNull: required("Attach.Role")},
+		{field: &a.Name, handleNull: func() error { return errorNew("Attach.Name is required") }},
+		{field: &a.Handle, handleNull: func() error { return errorNew("Attach.Handle is required") }},
+		{field: &a.Role, handleNull: func() error { return errorNew("Attach.Role is required") }},
 		{field: &a.SenderSettleMode},
 		{field: &a.ReceiverSettleMode},
 		{field: &a.Source},
@@ -574,22 +575,25 @@ func (u unsettled) marshal(wr writer) error {
 }
 
 func (u *unsettled) unmarshal(r reader) error {
-	mr, err := newMapReader(r)
+	_, count, err := readMapHeader(r)
 	if err != nil {
 		return err
 	}
 
-	mm := make(unsettled, mr.pairs())
-	for mr.more() {
-		var key string
-		var value deliveryState
-		err = mr.next(&key, &value)
+	m := make(unsettled, count/2)
+	for i := uint8(0); i < count; i += 2 {
+		key, err := readString(r)
 		if err != nil {
 			return err
 		}
-		mm[key] = value
+		var value deliveryState
+		_, err = unmarshal(r, &value)
+		if err != nil {
+			return err
+		}
+		m[key] = value
 	}
-	*u = mm
+	*u = m
 	return nil
 }
 
@@ -729,17 +733,17 @@ type source struct {
 
 func (s *source) marshal(wr writer) error {
 	return marshalComposite(wr, typeCodeSource, []marshalField{
-		{value: s.Address, omit: s.Address == ""},
-		{value: s.Durable, omit: s.Durable == 0},
-		{value: s.ExpiryPolicy, omit: s.ExpiryPolicy == ""},
-		{value: s.Timeout, omit: s.Timeout == 0},
-		{value: s.Dynamic, omit: !s.Dynamic},
+		{value: &s.Address, omit: s.Address == ""},
+		{value: &s.Durable, omit: s.Durable == 0},
+		{value: &s.ExpiryPolicy, omit: s.ExpiryPolicy == ""},
+		{value: &s.Timeout, omit: s.Timeout == 0},
+		{value: &s.Dynamic, omit: !s.Dynamic},
 		{value: s.DynamicNodeProperties, omit: len(s.DynamicNodeProperties) == 0},
-		{value: s.DistributionMode, omit: s.DistributionMode == ""},
+		{value: &s.DistributionMode, omit: s.DistributionMode == ""},
 		{value: s.Filter, omit: len(s.Filter) == 0},
 		{value: s.DefaultOutcome, omit: s.DefaultOutcome == nil},
-		{value: s.Outcomes, omit: len(s.Outcomes) == 0},
-		{value: s.Capabilities, omit: len(s.Capabilities) == 0},
+		{value: &s.Outcomes, omit: len(s.Outcomes) == 0},
+		{value: &s.Capabilities, omit: len(s.Capabilities) == 0},
 	}...)
 }
 
@@ -747,7 +751,7 @@ func (s *source) unmarshal(r reader) error {
 	return unmarshalComposite(r, typeCodeSource, []unmarshalField{
 		{field: &s.Address},
 		{field: &s.Durable},
-		{field: &s.ExpiryPolicy, handleNull: defaultSymbol(&s.ExpiryPolicy, "session-end")},
+		{field: &s.ExpiryPolicy, handleNull: func() error { s.ExpiryPolicy = "session-end"; return nil }},
 		{field: &s.Timeout},
 		{field: &s.Dynamic},
 		{field: &s.DynamicNodeProperties},
@@ -876,13 +880,13 @@ type target struct {
 
 func (t *target) marshal(wr writer) error {
 	return marshalComposite(wr, typeCodeTarget, []marshalField{
-		{value: t.Address, omit: t.Address == ""},
-		{value: t.Durable, omit: t.Durable == 0},
-		{value: t.ExpiryPolicy, omit: t.ExpiryPolicy == ""},
-		{value: t.Timeout, omit: t.Timeout == 0},
-		{value: t.Dynamic, omit: !t.Dynamic},
+		{value: &t.Address, omit: t.Address == ""},
+		{value: &t.Durable, omit: t.Durable == 0},
+		{value: &t.ExpiryPolicy, omit: t.ExpiryPolicy == ""},
+		{value: &t.Timeout, omit: t.Timeout == 0},
+		{value: &t.Dynamic, omit: !t.Dynamic},
 		{value: t.DynamicNodeProperties, omit: len(t.DynamicNodeProperties) == 0},
-		{value: t.Capabilities, omit: len(t.Capabilities) == 0},
+		{value: &t.Capabilities, omit: len(t.Capabilities) == 0},
 	}...)
 }
 
@@ -890,7 +894,7 @@ func (t *target) unmarshal(r reader) error {
 	return unmarshalComposite(r, typeCodeTarget, []unmarshalField{
 		{field: &t.Address},
 		{field: &t.Durable},
-		{field: &t.ExpiryPolicy, handleNull: defaultSymbol(&t.ExpiryPolicy, "session-end")},
+		{field: &t.ExpiryPolicy, handleNull: func() error { t.ExpiryPolicy = "session-end"; return nil }},
 		{field: &t.Timeout},
 		{field: &t.Dynamic},
 		{field: &t.DynamicNodeProperties},
@@ -1060,15 +1064,15 @@ func (f *performFlow) link() (uint32, bool) {
 func (f *performFlow) marshal(wr writer) error {
 	return marshalComposite(wr, typeCodeFlow, []marshalField{
 		{value: f.NextIncomingID, omit: f.NextIncomingID == nil},
-		{value: f.IncomingWindow, omit: false},
-		{value: f.NextOutgoingID, omit: false},
-		{value: f.OutgoingWindow, omit: false},
+		{value: &f.IncomingWindow, omit: false},
+		{value: &f.NextOutgoingID, omit: false},
+		{value: &f.OutgoingWindow, omit: false},
 		{value: f.Handle, omit: f.Handle == nil},
 		{value: f.DeliveryCount, omit: f.DeliveryCount == nil},
 		{value: f.LinkCredit, omit: f.LinkCredit == nil},
 		{value: f.Available, omit: f.Available == nil},
-		{value: f.Drain, omit: !f.Drain},
-		{value: f.Echo, omit: !f.Echo},
+		{value: &f.Drain, omit: !f.Drain},
+		{value: &f.Echo, omit: !f.Echo},
 		{value: f.Properties, omit: len(f.Properties) == 0},
 	}...)
 }
@@ -1076,9 +1080,9 @@ func (f *performFlow) marshal(wr writer) error {
 func (f *performFlow) unmarshal(r reader) error {
 	return unmarshalComposite(r, typeCodeFlow, []unmarshalField{
 		{field: &f.NextIncomingID},
-		{field: &f.IncomingWindow, handleNull: required("Flow.IncomingWindow")},
-		{field: &f.NextOutgoingID, handleNull: required("Flow.NextOutgoingID")},
-		{field: &f.OutgoingWindow, handleNull: required("Flow.OutgoingWindow")},
+		{field: &f.IncomingWindow, handleNull: func() error { return errorNew("Flow.IncomingWindow is required") }},
+		{field: &f.NextOutgoingID, handleNull: func() error { return errorNew("Flow.NextOutgoingID is required") }},
+		{field: &f.OutgoingWindow, handleNull: func() error { return errorNew("Flow.OutgoingWindow is required") }},
 		{field: &f.Handle},
 		{field: &f.DeliveryCount},
 		{field: &f.LinkCredit},
@@ -1279,17 +1283,17 @@ func (t *performTransfer) link() (uint32, bool) {
 
 func (t *performTransfer) marshal(wr writer) error {
 	err := marshalComposite(wr, typeCodeTransfer, []marshalField{
-		{value: t.Handle},
+		{value: &t.Handle},
 		{value: t.DeliveryID, omit: t.DeliveryID == nil},
-		{value: t.DeliveryTag, omit: len(t.DeliveryTag) == 0},
+		{value: &t.DeliveryTag, omit: len(t.DeliveryTag) == 0},
 		{value: t.MessageFormat, omit: t.MessageFormat == nil},
-		{value: t.Settled, omit: !t.Settled},
-		{value: t.More, omit: !t.More},
+		{value: &t.Settled, omit: !t.Settled},
+		{value: &t.More, omit: !t.More},
 		{value: t.ReceiverSettleMode, omit: t.ReceiverSettleMode == nil},
 		{value: t.State, omit: t.State == nil},
-		{value: t.Resume, omit: !t.Resume},
-		{value: t.Aborted, omit: !t.Aborted},
-		{value: t.Batchable, omit: !t.Batchable},
+		{value: &t.Resume, omit: !t.Resume},
+		{value: &t.Aborted, omit: !t.Aborted},
+		{value: &t.Batchable, omit: !t.Batchable},
 	}...)
 	if err != nil {
 		return err
@@ -1301,7 +1305,7 @@ func (t *performTransfer) marshal(wr writer) error {
 
 func (t *performTransfer) unmarshal(r reader) error {
 	err := unmarshalComposite(r, typeCodeTransfer, []unmarshalField{
-		{field: &t.Handle, handleNull: required("Transfer.Handle")},
+		{field: &t.Handle, handleNull: func() error { return errorNew("Transfer.Handle is required") }},
 		{field: &t.DeliveryID},
 		{field: &t.DeliveryTag},
 		{field: &t.MessageFormat},
@@ -1388,19 +1392,19 @@ func (*performDisposition) link() (uint32, bool) {
 
 func (d *performDisposition) marshal(wr writer) error {
 	return marshalComposite(wr, typeCodeDisposition, []marshalField{
-		{value: d.Role, omit: false},
-		{value: d.First, omit: false},
+		{value: &d.Role, omit: false},
+		{value: &d.First, omit: false},
 		{value: d.Last, omit: d.Last == nil},
-		{value: d.Settled, omit: !d.Settled},
+		{value: &d.Settled, omit: !d.Settled},
 		{value: d.State, omit: d.State == nil},
-		{value: d.Batchable, omit: !d.Batchable},
+		{value: &d.Batchable, omit: !d.Batchable},
 	}...)
 }
 
 func (d *performDisposition) unmarshal(r reader) error {
 	return unmarshalComposite(r, typeCodeDisposition, []unmarshalField{
-		{field: &d.Role, handleNull: required("Disposition.Role")},
-		{field: &d.First, handleNull: required("Disposition.First")},
+		{field: &d.Role, handleNull: func() error { return errorNew("Disposition.Role is required") }},
+		{field: &d.First, handleNull: func() error { return errorNew("Disposition.Handle is required") }},
 		{field: &d.Last},
 		{field: &d.Settled},
 		{field: &d.State},
@@ -1444,15 +1448,15 @@ func (d *performDetach) link() (uint32, bool) {
 
 func (d *performDetach) marshal(wr writer) error {
 	return marshalComposite(wr, typeCodeDetach, []marshalField{
-		{value: d.Handle, omit: false},
-		{value: d.Closed, omit: !d.Closed},
+		{value: &d.Handle, omit: false},
+		{value: &d.Closed, omit: !d.Closed},
 		{value: d.Error, omit: d.Error == nil},
 	}...)
 }
 
 func (d *performDetach) unmarshal(r reader) error {
 	return unmarshalComposite(r, typeCodeDetach, []unmarshalField{
-		{field: &d.Handle, handleNull: required("Detach.Handle")},
+		{field: &d.Handle, handleNull: func() error { return errorNew("Detach.Handle is required") }},
 		{field: &d.Closed},
 		{field: &d.Error},
 	}...)
@@ -1536,15 +1540,15 @@ type Error struct {
 
 func (e *Error) marshal(wr writer) error {
 	return marshalComposite(wr, typeCodeError, []marshalField{
-		{value: e.Condition, omit: false},
-		{value: e.Description, omit: e.Description == ""},
+		{value: &e.Condition, omit: false},
+		{value: &e.Description, omit: e.Description == ""},
 		{value: e.Info, omit: len(e.Info) == 0},
 	}...)
 }
 
 func (e *Error) unmarshal(r reader) error {
 	return unmarshalComposite(r, typeCodeError, []unmarshalField{
-		{field: &e.Condition, handleNull: required("Error.Condition")},
+		{field: &e.Condition, handleNull: func() error { return errorNew("Error.Condition is required") }},
 		{field: &e.Description},
 		{field: &e.Info},
 	}...)
@@ -1792,7 +1796,7 @@ func (m *Message) marshal(wr writer) error {
 		if err != nil {
 			return err
 		}
-		err = marshal(wr, m.Data)
+		err = writeBinary(wr, m.Data)
 		if err != nil {
 			return err
 		}
@@ -1899,11 +1903,29 @@ func peekMessageType(buf []byte) (uint8, error) {
 		return 0, errorErrorf("invalid composite header %0x", buf[0])
 	}
 
-	v, err := readUlong(&roReader{b: buf[1:]})
-	if err != nil {
-		return 0, err
+	// copied from readUlong to avoid allocations
+	t := amqpType(buf[1])
+	if t == typeCodeUlong0 {
+		return 0, nil
 	}
-	return uint8(v), err
+
+	if t == typeCodeSmallUlong {
+		if len(buf[2:]) == 0 {
+			errorNew("invalid ulong")
+		}
+		return uint8(buf[2]), nil
+	}
+
+	if t != typeCodeUlong {
+		return 0, errorErrorf("invalid type for uint32 %0x", t)
+	}
+
+	if len(buf[2:]) < 8 {
+		return 0, errorNew("invalid ulong")
+	}
+	v := binary.BigEndian.Uint64(buf[2:10])
+
+	return uint8(v), nil
 }
 
 func checkNull(buf []byte) bool {
@@ -1933,18 +1955,18 @@ type MessageHeader struct {
 
 func (h *MessageHeader) marshal(wr writer) error {
 	return marshalComposite(wr, typeCodeMessageHeader, []marshalField{
-		{value: h.Durable, omit: !h.Durable},
-		{value: h.Priority, omit: h.Priority == 4},
-		{value: milliseconds(h.TTL), omit: h.TTL == 0},
-		{value: h.FirstAcquirer, omit: !h.FirstAcquirer},
-		{value: h.DeliveryCount, omit: h.DeliveryCount == 0},
+		{value: &h.Durable, omit: !h.Durable},
+		{value: &h.Priority, omit: h.Priority == 4},
+		{value: (*milliseconds)(&h.TTL), omit: h.TTL == 0},
+		{value: &h.FirstAcquirer, omit: !h.FirstAcquirer},
+		{value: &h.DeliveryCount, omit: h.DeliveryCount == 0},
 	}...)
 }
 
 func (h *MessageHeader) unmarshal(r reader) error {
 	return unmarshalComposite(r, typeCodeMessageHeader, []unmarshalField{
 		{field: &h.Durable},
-		{field: &h.Priority, handleNull: defaultUint8(&h.Priority, 4)},
+		{field: &h.Priority, handleNull: func() error { h.Priority = 4; return nil }},
 		{field: (*milliseconds)(&h.TTL)},
 		{field: &h.FirstAcquirer},
 		{field: &h.DeliveryCount},
@@ -1992,18 +2014,18 @@ type MessageProperties struct {
 func (p *MessageProperties) marshal(wr writer) error {
 	return marshalComposite(wr, typeCodeMessageProperties, []marshalField{
 		{value: p.MessageID, omit: p.MessageID == nil},
-		{value: p.UserID, omit: len(p.UserID) == 0},
-		{value: p.To, omit: p.To == ""},
-		{value: p.Subject, omit: p.Subject == ""},
-		{value: p.ReplyTo, omit: p.ReplyTo == ""},
+		{value: &p.UserID, omit: len(p.UserID) == 0},
+		{value: &p.To, omit: p.To == ""},
+		{value: &p.Subject, omit: p.Subject == ""},
+		{value: &p.ReplyTo, omit: p.ReplyTo == ""},
 		{value: p.CorrelationID, omit: p.CorrelationID == nil},
-		{value: symbol(p.ContentType), omit: p.ContentType == ""},
-		{value: symbol(p.ContentEncoding), omit: p.ContentEncoding == ""},
-		{value: p.AbsoluteExpiryTime, omit: p.AbsoluteExpiryTime.IsZero()},
-		{value: p.CreationTime, omit: p.CreationTime.IsZero()},
-		{value: p.GroupID, omit: p.GroupID == ""},
-		{value: p.GroupSequence},
-		{value: p.ReplyToGroupID, omit: p.ReplyToGroupID == ""},
+		{value: (*symbol)(&p.ContentType), omit: p.ContentType == ""},
+		{value: (*symbol)(&p.ContentEncoding), omit: p.ContentEncoding == ""},
+		{value: &p.AbsoluteExpiryTime, omit: p.AbsoluteExpiryTime.IsZero()},
+		{value: &p.CreationTime, omit: p.CreationTime.IsZero()},
+		{value: &p.GroupID, omit: p.GroupID == ""},
+		{value: &p.GroupSequence},
+		{value: &p.ReplyToGroupID, omit: p.ReplyToGroupID == ""},
 	}...)
 }
 
@@ -2060,15 +2082,15 @@ type stateReceived struct {
 
 func (sr *stateReceived) marshal(wr writer) error {
 	return marshalComposite(wr, typeCodeStateReceived, []marshalField{
-		{value: sr.SectionNumber, omit: false},
-		{value: sr.SectionOffset, omit: false},
+		{value: &sr.SectionNumber, omit: false},
+		{value: &sr.SectionOffset, omit: false},
 	}...)
 }
 
 func (sr *stateReceived) unmarshal(r reader) error {
 	return unmarshalComposite(r, typeCodeStateReceived, []unmarshalField{
-		{field: &sr.SectionNumber, handleNull: required("StateReceived.SectionNumber")},
-		{field: &sr.SectionOffset, handleNull: required("StateReceived.SectionOffset")},
+		{field: &sr.SectionNumber, handleNull: func() error { return errorNew("StateReceiver.SectionNumber is required") }},
+		{field: &sr.SectionOffset, handleNull: func() error { return errorNew("StateReceiver.SectionOffset is required") }},
 	}...)
 }
 
@@ -2173,8 +2195,8 @@ type stateModified struct {
 
 func (sm *stateModified) marshal(wr writer) error {
 	return marshalComposite(wr, typeCodeStateModified, []marshalField{
-		{value: sm.DeliveryFailed, omit: !sm.DeliveryFailed},
-		{value: sm.UndeliverableHere, omit: !sm.UndeliverableHere},
+		{value: &sm.DeliveryFailed, omit: !sm.DeliveryFailed},
+		{value: &sm.UndeliverableHere, omit: !sm.UndeliverableHere},
 		{value: sm.MessageAnnotations, omit: sm.MessageAnnotations == nil},
 	}...)
 }
@@ -2212,15 +2234,15 @@ func (si *saslInit) link() (uint32, bool) {
 
 func (si *saslInit) marshal(wr writer) error {
 	return marshalComposite(wr, typeCodeSASLInit, []marshalField{
-		{value: si.Mechanism, omit: false},
-		{value: si.InitialResponse, omit: len(si.InitialResponse) == 0},
-		{value: si.Hostname, omit: len(si.Hostname) == 0},
+		{value: &si.Mechanism, omit: false},
+		{value: &si.InitialResponse, omit: len(si.InitialResponse) == 0},
+		{value: &si.Hostname, omit: len(si.Hostname) == 0},
 	}...)
 }
 
 func (si *saslInit) unmarshal(r reader) error {
 	return unmarshalComposite(r, typeCodeSASLInit, []unmarshalField{
-		{field: &si.Mechanism, handleNull: required("saslInit.Mechanism")},
+		{field: &si.Mechanism, handleNull: func() error { return errorNew("saslInit.Mechanism is required") }},
 		{field: &si.InitialResponse},
 		{field: &si.Hostname},
 	}...)
@@ -2239,13 +2261,13 @@ type saslMechanisms struct {
 
 func (sm saslMechanisms) marshal(wr writer) error {
 	return marshalComposite(wr, typeCodeSASLMechanism, []marshalField{
-		{value: sm.Mechanisms, omit: false},
+		{value: &sm.Mechanisms, omit: false},
 	}...)
 }
 
 func (sm *saslMechanisms) unmarshal(r reader) error {
 	return unmarshalComposite(r, typeCodeSASLMechanism,
-		unmarshalField{field: &sm.Mechanisms, handleNull: required("SASLMechanisms.Mechanisms")},
+		unmarshalField{field: &sm.Mechanisms, handleNull: func() error { return errorNew("saslMechanisms.Mechanisms is required") }},
 	)
 }
 
@@ -2268,20 +2290,90 @@ type saslOutcome struct {
 
 func (so saslOutcome) marshal(wr writer) error {
 	return marshalComposite(wr, typeCodeSASLOutcome, []marshalField{
-		{value: so.Code, omit: false},
-		{value: so.AdditionalData, omit: len(so.AdditionalData) == 0},
+		{value: &so.Code, omit: false},
+		{value: &so.AdditionalData, omit: len(so.AdditionalData) == 0},
 	}...)
 }
 
 func (so *saslOutcome) unmarshal(r reader) error {
 	return unmarshalComposite(r, typeCodeSASLOutcome, []unmarshalField{
-		{field: &so.Code, handleNull: required("SASLOutcome.Code")},
+		{field: &so.Code, handleNull: func() error { return errorNew("saslOutcome.AdditionalData is required") }},
 		{field: &so.AdditionalData},
 	}...)
 }
 
 func (*saslOutcome) link() (uint32, bool) {
 	return 0, false
+}
+
+type symbolSlice []symbol
+
+func (s symbolSlice) marshal(wr writer) error {
+	return writeSymbolArray(wr, s)
+}
+
+type amqpUint16 uint16
+
+func (n amqpUint16) marshal(wr writer) error {
+	err := wr.WriteByte(byte(typeCodeUshort))
+	if err != nil {
+		return err
+	}
+	tmp := make([]byte, 2)
+	binary.BigEndian.PutUint16(tmp, uint16(n))
+	_, err = wr.Write(tmp)
+	return err
+}
+
+type amqpUint32 uint32
+
+func (n amqpUint32) marshal(wr writer) error {
+	return writeUint32(wr, uint32(n))
+}
+
+// symbol is an AMQP symbolic string.
+type amqpString string
+
+func (s amqpString) marshal(wr writer) error {
+	if !utf8.ValidString(string(s)) {
+		return errorNew("not a valid UTF-8 string")
+	}
+	l := len(s)
+
+	switch {
+	// Str8
+	case l < 256:
+		err := wr.WriteByte(byte(typeCodeStr8))
+		if err != nil {
+			return err
+		}
+		err = wr.WriteByte(byte(l))
+		if err != nil {
+			return err
+		}
+		_, err = wr.WriteString(string(s))
+		return err
+
+	// Str32
+	case l < math.MaxUint32:
+		err := wr.WriteByte(byte(typeCodeStr32))
+		if err != nil {
+			return err
+		}
+
+		tmp := make([]byte, 4)
+		binary.BigEndian.PutUint32(tmp, uint32(l))
+		_, err = wr.Write(tmp)
+		if err != nil {
+			return err
+		}
+
+		_, err = wr.WriteString(string(s))
+		return err
+
+	default:
+		return errorNew("too long")
+	}
 }
 
 // symbol is an AMQP symbolic string.
@@ -2294,7 +2386,15 @@ func (s symbol) marshal(wr writer) error {
 	switch {
 	// Sym8
 	case l < 256:
-		_, err = wr.Write(append([]byte{byte(typeCodeSym8), byte(l)}, []byte(s)...))
+		err = wr.WriteByte(byte(typeCodeSym8))
+		if err != nil {
+			return err
+		}
+		err = wr.WriteByte(byte(l))
+		if err != nil {
+			return err
+		}
+		_, err = wr.WriteString(string(s))
 
 	// Sym32
 	case l < math.MaxUint32:
@@ -2302,11 +2402,13 @@ func (s symbol) marshal(wr writer) error {
 		if err != nil {
 			return err
 		}
-		err = binary.Write(wr, binary.BigEndian, uint32(l))
+		tmp := make([]byte, 4)
+		binary.BigEndian.PutUint32(tmp, uint32(l))
+		_, err := wr.Write(tmp)
 		if err != nil {
 			return err
 		}
-		_, err = wr.Write([]byte(s))
+		_, err = wr.WriteString(string(s))
 	default:
 		return errorNew("too long")
 	}
@@ -2335,16 +2437,18 @@ func (m mapAnyAny) marshal(wr writer) error {
 }
 
 func (m *mapAnyAny) unmarshal(r reader) error {
-	mr, err := newMapReader(r)
+	_, count, err := readMapHeader(r)
 	if err != nil {
 		return err
 	}
 
-	mm := make(mapAnyAny, mr.pairs())
-	for mr.more() {
-		var key interface{}
-		var value interface{}
-		err = mr.next(&key, &value)
+	mm := make(mapAnyAny, count/2)
+	for i := uint8(0); i < count; i += 2 {
+		key, err := readAny(r)
+		if err != nil {
+			return err
+		}
+		value, err := readAny(r)
 		if err != nil {
 			return err
 		}
@@ -2361,7 +2465,6 @@ func (m *mapAnyAny) unmarshal(r reader) error {
 		mm[key] = value
 	}
 	*m = mm
-
 	return nil
 }
 
@@ -2373,22 +2476,25 @@ func (m mapStringAny) marshal(wr writer) error {
 }
 
 func (m *mapStringAny) unmarshal(r reader) error {
-	mr, err := newMapReader(r)
+	_, count, err := readMapHeader(r)
 	if err != nil {
 		return err
 	}
 
-	mm := make(mapStringAny, mr.pairs())
-	for mr.more() {
-		var key string
-		var value interface{}
-		err = mr.next(&key, &value)
+	mm := make(mapStringAny, count/2)
+	for i := uint8(0); i < count; i += 2 {
+		key, err := readString(r)
+		if err != nil {
+			return err
+		}
+		value, err := readAny(r)
 		if err != nil {
 			return err
 		}
 		mm[key] = value
 	}
 	*m = mm
+
 	return nil
 }
 
@@ -2464,8 +2570,19 @@ const (
 )
 
 func (p lifetimePolicy) marshal(wr writer) error {
-	_, err := wr.Write([]byte{0x0, byte(typeCodeSmallUlong), byte(p), byte(typeCodeList0)})
-	return err
+	err := wr.WriteByte(byte(0x0))
+	if err != nil {
+		return err
+	}
+	err = wr.WriteByte(byte(typeCodeSmallUlong))
+	if err != nil {
+		return err
+	}
+	err = wr.WriteByte(byte(p))
+	if err != nil {
+		return err
+	}
+	return wr.WriteByte(byte(typeCodeList0))
 }
 
 func (p *lifetimePolicy) unmarshal(r reader) error {


### PR DESCRIPTION
Reductions primary involve:
* Eliminating creating temporary slices.
* Avoid interface conversion of non-pointers.
* Avoid multiple copies of binary and string data.
* Remove closures which escape.

Overall Results:
```
name                                  old time/op    new time/op    delta
FrameMarshal/transfer-8                 1.39µs ± 1%    0.42µs ± 5%   -69.57%  (p=0.000 n=8+10)
FrameUnmarshal/transfer-8               2.59µs ± 0%    1.87µs ± 0%   -27.76%  (p=0.000 n=8+9)
Marshal/*amqp.performOpen-8             1.84µs ± 0%    0.75µs ± 1%   -59.27%  (p=0.000 n=7+10)
Marshal/*amqp.performBegin-8            1.45µs ± 1%    0.60µs ± 1%   -58.93%  (p=0.000 n=10+9)
Marshal/*amqp.performAttach-8           5.20µs ± 1%    2.36µs ± 1%   -54.64%  (p=0.000 n=10+10)
Marshal/amqp.role-8                     31.9ns ± 2%    30.8ns ± 5%    -3.32%  (p=0.004 n=9+10)
Marshal/*amqp.unsettled-8                376ns ± 5%     243ns ± 9%   -35.31%  (p=0.000 n=10+9)
Marshal/*amqp.source-8                  1.94µs ± 2%    0.87µs ± 1%   -55.30%  (p=0.000 n=10+10)
Marshal/*amqp.target-8                  1.14µs ± 2%    0.50µs ± 1%   -56.33%  (p=0.000 n=10+10)
Marshal/*amqp.performFlow-8             1.19µs ± 1%    0.56µs ± 1%   -53.10%  (p=0.000 n=10+10)
Marshal/*amqp.performTransfer-8          844ns ± 1%     390ns ± 4%   -53.72%  (p=0.000 n=10+10)
Marshal/*amqp.performDisposition-8       410ns ± 1%     221ns ± 3%   -46.24%  (p=0.000 n=8+10)
Marshal/*amqp.performDetach-8           1.32µs ± 1%    0.62µs ± 1%   -52.71%  (p=0.000 n=9+10)
Marshal/amqp.ErrorCondition-8            118ns ± 2%      70ns ± 1%   -40.59%  (p=0.000 n=10+10)
Marshal/*amqp.Error-8                   1.06µs ± 5%    0.50µs ± 2%   -52.45%  (p=0.000 n=10+10)
Marshal/*amqp.performEnd-8              1.24µs ± 2%    0.61µs ± 1%   -51.09%  (p=0.000 n=10+9)
Marshal/*amqp.performClose-8            1.24µs ± 1%    0.61µs ± 1%   -50.91%  (p=0.000 n=9+10)
Marshal/*amqp.Message-8                 3.74µs ± 3%    1.76µs ± 2%   -52.95%  (p=0.000 n=10+10)
Marshal/*amqp.MessageHeader-8            394ns ± 1%     195ns ± 3%   -50.48%  (p=0.000 n=10+10)
Marshal/*amqp.MessageProperties-8       1.57µs ± 2%    0.52µs ± 4%   -66.79%  (p=0.000 n=10+10)
Marshal/*amqp.stateReceived-8            294ns ± 1%     134ns ± 3%   -54.34%  (p=0.000 n=10+9)
Marshal/*amqp.stateAccepted-8           37.5ns ± 1%    30.6ns ± 8%   -18.24%  (p=0.000 n=10+10)
Marshal/*amqp.stateRejected-8           1.25µs ± 2%    0.61µs ± 1%   -51.01%  (p=0.000 n=9+10)
Marshal/*amqp.stateReleased-8           37.5ns ± 1%    30.3ns ± 2%   -19.11%  (p=0.000 n=10+9)
Marshal/*amqp.stateModified-8            594ns ± 1%     336ns ± 7%   -43.48%  (p=0.000 n=10+10)
Marshal/amqp.UUID-8                     48.3ns ± 6%    46.8ns ± 3%    -3.03%  (p=0.011 n=10+10)
Marshal/amqp.lifetimePolicy-8           35.7ns ± 2%    29.5ns ± 5%   -17.21%  (p=0.000 n=10+10)
Marshal/amqp.SenderSettleMode-8         46.3ns ± 1%    33.9ns ± 3%   -26.79%  (p=0.000 n=9+9)
Marshal/amqp.ReceiverSettleMode-8       45.8ns ± 3%    33.5ns ± 4%   -26.88%  (p=0.000 n=10+10)
Marshal/bool-8                          16.1ns ± 5%    15.9ns ± 4%      ~     (p=0.445 n=10+10)
Marshal/int8-8                          48.9ns ± 1%    19.1ns ± 3%   -60.99%  (p=0.000 n=10+10)
Marshal/int8#01-8                       48.9ns ± 1%    19.1ns ± 4%   -60.81%  (p=0.000 n=9+10)
Marshal/int16-8                         66.2ns ± 2%    25.1ns ± 1%   -62.13%  (p=0.000 n=10+7)
Marshal/int16#01-8                      66.0ns ± 1%    24.7ns ± 4%   -62.57%  (p=0.000 n=10+10)
Marshal/int32-8                         67.0ns ± 1%    33.8ns ± 1%   -49.56%  (p=0.000 n=10+9)
Marshal/int32#01-8                      66.9ns ± 2%    33.0ns ± 4%   -50.72%  (p=0.000 n=10+10)
Marshal/int64-8                         67.9ns ± 1%    46.7ns ± 2%   -31.18%  (p=0.000 n=10+9)
Marshal/int64#01-8                      68.0ns ± 1%    45.8ns ± 5%   -32.57%  (p=0.000 n=9+10)
Marshal/uint8-8                         29.8ns ± 2%    19.1ns ± 5%   -35.88%  (p=0.000 n=10+10)
Marshal/uint16-8                        66.6ns ± 1%    25.0ns ± 4%   -62.37%  (p=0.000 n=10+10)
Marshal/uint32-8                        67.8ns ± 2%    33.7ns ± 4%   -50.32%  (p=0.000 n=10+10)
Marshal/uint64-8                        67.9ns ± 1%    46.9ns ± 2%   -30.98%  (p=0.000 n=10+9)
Marshal/amqp.describedType-8             287ns ± 9%     118ns ± 1%   -58.97%  (p=0.000 n=9+6)
Marshal/*amqp.saslInit-8                 462ns ± 2%     157ns ± 6%   -65.94%  (p=0.000 n=10+10)
Marshal/*amqp.saslMechanisms-8           502ns ± 2%     212ns ± 1%   -57.81%  (p=0.000 n=10+10)
Marshal/*amqp.saslOutcome-8              316ns ± 2%     169ns ± 1%   -46.70%  (p=0.000 n=10+10)
Marshal/amqp.symbol-8                   72.0ns ± 1%    29.8ns ± 2%   -58.55%  (p=0.000 n=10+9)
Marshal/amqp.milliseconds-8             92.2ns ± 1%    60.5ns ± 2%   -34.35%  (p=0.000 n=10+10)
Marshal/*amqp.mapAnyAny-8                379ns ± 5%     262ns ± 9%   -30.97%  (p=0.000 n=10+10)
Marshal/*amqp.mapStringAny-8             414ns ±13%     232ns ± 4%   -43.98%  (p=0.000 n=9+9)
Marshal/*amqp.mapSymbolAny-8             415ns ±10%     228ns ± 7%   -45.21%  (p=0.000 n=10+10)
Unmarshal/*amqp.performOpen-8           2.92µs ± 4%    1.87µs ± 2%   -35.78%  (p=0.000 n=10+9)
Unmarshal/*amqp.performBegin-8          2.52µs ± 5%    1.45µs ± 2%   -42.53%  (p=0.000 n=10+7)
Unmarshal/*amqp.performAttach-8         10.2µs ± 4%     6.5µs ± 5%   -36.75%  (p=0.000 n=10+10)
Unmarshal/amqp.role-8                    262ns ±20%     217ns ± 5%   -17.02%  (p=0.000 n=10+9)
Unmarshal/*amqp.unsettled-8             1.57µs ±14%    0.91µs ±25%   -42.03%  (p=0.000 n=10+10)
Unmarshal/*amqp.source-8                3.71µs ± 7%    2.47µs ± 7%   -33.45%  (p=0.000 n=10+10)
Unmarshal/*amqp.target-8                2.19µs ± 4%    1.49µs ± 5%   -32.02%  (p=0.000 n=10+10)
Unmarshal/*amqp.performFlow-8           3.02µs ± 3%    1.83µs ± 1%   -39.33%  (p=0.000 n=10+10)
Unmarshal/*amqp.performTransfer-8       2.12µs ± 1%    1.74µs ± 2%   -18.22%  (p=0.000 n=10+10)
Unmarshal/*amqp.performDisposition-8    1.25µs ± 1%    0.92µs ± 1%   -26.27%  (p=0.000 n=10+10)
Unmarshal/*amqp.performDetach-8         2.52µs ± 3%    1.53µs ± 3%   -39.46%  (p=0.000 n=9+8)
Unmarshal/amqp.ErrorCondition-8          342ns ±11%     261ns ±10%   -23.65%  (p=0.000 n=10+10)
Unmarshal/*amqp.Error-8                 2.12µs ± 9%    1.17µs ± 4%   -44.77%  (p=0.000 n=10+9)
Unmarshal/*amqp.performEnd-8            2.35µs ± 6%    1.37µs ± 3%   -41.63%  (p=0.000 n=10+8)
Unmarshal/*amqp.performClose-8          2.30µs ± 4%    1.40µs ± 3%   -39.35%  (p=0.000 n=10+8)
Unmarshal/*amqp.Message-8               8.86µs ± 5%    4.86µs ± 3%   -45.18%  (p=0.000 n=10+9)
Unmarshal/*amqp.MessageHeader-8          811ns ± 1%     650ns ± 1%   -19.85%  (p=0.000 n=10+10)
Unmarshal/*amqp.MessageProperties-8     2.09µs ± 1%    1.51µs ± 2%   -27.69%  (p=0.000 n=9+10)
Unmarshal/*amqp.stateReceived-8          580ns ± 4%     390ns ± 1%   -32.82%  (p=0.000 n=10+10)
Unmarshal/*amqp.stateAccepted-8          286ns ±10%     253ns ±13%   -11.65%  (p=0.002 n=10+10)
Unmarshal/*amqp.stateRejected-8         2.37µs ± 8%    1.43µs ± 7%   -39.51%  (p=0.000 n=10+10)
Unmarshal/*amqp.stateReleased-8          298ns ±12%     272ns ± 6%    -8.91%  (p=0.000 n=10+10)
Unmarshal/*amqp.stateModified-8         1.50µs ± 9%    1.04µs ±10%   -30.50%  (p=0.000 n=10+10)
Unmarshal/amqp.UUID-8                    260ns ±22%     223ns ±14%   -14.26%  (p=0.021 n=10+9)
Unmarshal/amqp.lifetimePolicy-8          225ns ± 7%     203ns ±13%    -9.89%  (p=0.002 n=10+10)
Unmarshal/amqp.SenderSettleMode-8        255ns ±13%     217ns ±14%   -14.79%  (p=0.000 n=10+9)
Unmarshal/amqp.ReceiverSettleMode-8      251ns ±13%     220ns ±14%   -12.42%  (p=0.000 n=10+10)
Unmarshal/bool-8                         200ns ±11%     185ns ±15%    -7.55%  (p=0.021 n=9+10)
Unmarshal/int8-8                         276ns ± 8%     204ns ±15%   -26.19%  (p=0.000 n=8+9)
Unmarshal/int8#01-8                      293ns ±13%     196ns ±19%   -33.04%  (p=0.000 n=10+10)
Unmarshal/int16-8                        296ns ±18%     195ns ±14%   -34.05%  (p=0.000 n=10+9)
Unmarshal/int16#01-8                     289ns ±15%     193ns ±14%   -33.18%  (p=0.000 n=10+10)
Unmarshal/int32-8                        276ns ±11%     188ns ±15%   -31.87%  (p=0.000 n=10+10)
Unmarshal/int32#01-8                     284ns ±11%     181ns ±18%   -36.50%  (p=0.000 n=10+10)
Unmarshal/int64-8                        286ns ±18%     196ns ±17%   -31.39%  (p=0.000 n=10+10)
Unmarshal/int64#01-8                     279ns ±13%     195ns ±12%   -30.08%  (p=0.000 n=10+10)
Unmarshal/uint8-8                        216ns ±23%     175ns ±17%   -19.25%  (p=0.001 n=10+10)
Unmarshal/uint16-8                       271ns ±21%     184ns ±21%   -31.87%  (p=0.000 n=10+10)
Unmarshal/uint32-8                       274ns ± 6%     177ns ±27%   -35.27%  (p=0.000 n=8+10)
Unmarshal/uint64-8                       280ns ±12%     187ns ±12%   -33.25%  (p=0.000 n=10+9)
Unmarshal/amqp.describedType-8           609ns ±15%     436ns ± 8%   -28.40%  (p=0.000 n=10+10)
Unmarshal/*amqp.saslInit-8               701ns ± 1%     566ns ± 1%   -19.23%  (p=0.000 n=9+10)
Unmarshal/*amqp.saslMechanisms-8         852ns ± 7%     523ns ± 5%   -38.59%  (p=0.000 n=10+10)
Unmarshal/*amqp.saslOutcome-8            591ns ± 2%     525ns ± 3%   -11.23%  (p=0.000 n=10+10)
Unmarshal/amqp.symbol-8                  284ns ±11%     224ns ±21%   -21.06%  (p=0.000 n=10+10)
Unmarshal/amqp.milliseconds-8            312ns ±15%     184ns ±17%   -41.10%  (p=0.000 n=10+10)
Unmarshal/*amqp.mapAnyAny-8             1.34µs ±13%    0.95µs ±16%   -28.94%  (p=0.000 n=10+10)
Unmarshal/*amqp.mapStringAny-8          1.37µs ±25%    0.88µs ±22%   -35.62%  (p=0.000 n=10+10)
Unmarshal/*amqp.mapSymbolAny-8          1.29µs ±21%    0.89µs ±29%   -31.31%  (p=0.000 n=9+10)

name                                  old alloc/op   new alloc/op   delta
FrameMarshal/transfer-8                   184B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
FrameUnmarshal/transfer-8                 592B ± 0%      312B ± 0%   -47.30%  (p=0.000 n=10+10)
Marshal/*amqp.performOpen-8               448B ± 0%      112B ± 0%   -75.00%  (p=0.000 n=10+10)
Marshal/*amqp.performBegin-8              344B ± 0%      112B ± 0%   -67.44%  (p=0.000 n=10+10)
Marshal/*amqp.performAttach-8           1.44kB ± 0%    0.56kB ± 0%   -61.11%  (p=0.000 n=10+10)
Marshal/amqp.role-8                      0.00B          0.00B           ~     (all equal)
Marshal/*amqp.unsettled-8                 152B ± 0%      112B ± 0%   -26.32%  (p=0.000 n=10+10)
Marshal/*amqp.source-8                    584B ± 0%      224B ± 0%   -61.64%  (p=0.000 n=10+10)
Marshal/*amqp.target-8                    320B ± 0%      112B ± 0%   -65.00%  (p=0.000 n=10+10)
Marshal/*amqp.performFlow-8               296B ± 0%      112B ± 0%   -62.16%  (p=0.000 n=10+10)
Marshal/*amqp.performTransfer-8           104B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.performDisposition-8       48.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.performDetach-8             352B ± 0%      128B ± 0%   -63.64%  (p=0.000 n=10+10)
Marshal/amqp.ErrorCondition-8            34.0B ± 0%     16.0B ± 0%   -52.94%  (p=0.000 n=10+10)
Marshal/*amqp.Error-8                     328B ± 0%      128B ± 0%   -60.98%  (p=0.000 n=10+10)
Marshal/*amqp.performEnd-8                336B ± 0%      128B ± 0%   -61.90%  (p=0.000 n=10+10)
Marshal/*amqp.performClose-8              336B ± 0%      128B ± 0%   -61.90%  (p=0.000 n=10+10)
Marshal/*amqp.Message-8                 1.13kB ± 0%    0.45kB ± 0%   -59.93%  (p=0.000 n=10+10)
Marshal/*amqp.MessageHeader-8            40.0B ± 0%      4.0B ± 0%   -90.00%  (p=0.000 n=10+10)
Marshal/*amqp.MessageProperties-8         424B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.stateReceived-8            48.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.stateAccepted-8            4.00B ± 0%     0.00B       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.stateRejected-8             336B ± 0%      128B ± 0%   -61.90%  (p=0.000 n=10+10)
Marshal/*amqp.stateReleased-8            4.00B ± 0%     0.00B       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.stateModified-8             168B ± 0%      112B ± 0%   -33.33%  (p=0.000 n=10+10)
Marshal/amqp.UUID-8                      16.0B ± 0%     16.0B ± 0%      ~     (all equal)
Marshal/amqp.lifetimePolicy-8            4.00B ± 0%     0.00B       -100.00%  (p=0.000 n=10+10)
Marshal/amqp.SenderSettleMode-8          2.00B ± 0%     0.00B       -100.00%  (p=0.000 n=10+10)
Marshal/amqp.ReceiverSettleMode-8        2.00B ± 0%     0.00B       -100.00%  (p=0.000 n=10+10)
Marshal/bool-8                           0.00B          0.00B           ~     (all equal)
Marshal/int8-8                           8.00B ± 0%     0.00B       -100.00%  (p=0.000 n=10+10)
Marshal/int8#01-8                        8.00B ± 0%     0.00B       -100.00%  (p=0.000 n=10+10)
Marshal/int16-8                          16.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
Marshal/int16#01-8                       16.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
Marshal/int32-8                          16.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
Marshal/int32#01-8                       16.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
Marshal/int64-8                          16.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
Marshal/int64#01-8                       16.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
Marshal/uint8-8                          2.00B ± 0%     0.00B       -100.00%  (p=0.000 n=10+10)
Marshal/uint16-8                         16.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
Marshal/uint32-8                         16.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
Marshal/uint64-8                         16.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
Marshal/amqp.describedType-8              120B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.saslInit-8                  112B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.saslMechanisms-8           72.0B ± 0%     32.0B ± 0%   -55.56%  (p=0.000 n=10+10)
Marshal/*amqp.saslOutcome-8              74.0B ± 0%     32.0B ± 0%   -56.76%  (p=0.000 n=10+10)
Marshal/amqp.symbol-8                    18.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
Marshal/amqp.milliseconds-8              16.0B ± 0%      4.0B ± 0%   -75.00%  (p=0.000 n=10+10)
Marshal/*amqp.mapAnyAny-8                 152B ± 0%      112B ± 0%   -26.32%  (p=0.000 n=10+10)
Marshal/*amqp.mapStringAny-8              160B ± 0%      112B ± 0%   -30.00%  (p=0.000 n=10+10)
Marshal/*amqp.mapSymbolAny-8              160B ± 0%      112B ± 0%   -30.00%  (p=0.000 n=10+10)
Unmarshal/*amqp.performOpen-8             896B ± 0%      624B ± 0%   -30.36%  (p=0.000 n=10+10)
Unmarshal/*amqp.performBegin-8            848B ± 0%      528B ± 0%   -37.74%  (p=0.000 n=10+10)
Unmarshal/*amqp.performAttach-8         3.31kB ± 0%    2.24kB ± 0%   -32.37%  (p=0.000 n=10+10)
Unmarshal/amqp.role-8                     112B ± 0%      112B ± 0%      ~     (all equal)
Unmarshal/*amqp.unsettled-8               692B ± 0%      480B ± 0%   -30.64%  (p=0.000 n=10+10)
Unmarshal/*amqp.source-8                1.38kB ± 0%    1.01kB ± 0%   -26.74%  (p=0.000 n=10+10)
Unmarshal/*amqp.target-8                  752B ± 0%      560B ± 0%   -25.53%  (p=0.000 n=10+10)
Unmarshal/*amqp.performFlow-8             808B ± 0%      464B ± 0%   -42.57%  (p=0.000 n=10+10)
Unmarshal/*amqp.performTransfer-8         408B ± 0%      168B ± 0%   -58.82%  (p=0.000 n=10+10)
Unmarshal/*amqp.performDisposition-8      320B ± 0%      112B ± 0%   -65.00%  (p=0.000 n=10+10)
Unmarshal/*amqp.performDetach-8           800B ± 0%      520B ± 0%   -35.00%  (p=0.000 n=10+10)
Unmarshal/amqp.ErrorCondition-8           144B ± 0%      128B ± 0%   -11.11%  (p=0.000 n=10+10)
Unmarshal/*amqp.Error-8                   752B ± 0%      520B ± 0%   -30.85%  (p=0.000 n=10+10)
Unmarshal/*amqp.performEnd-8              752B ± 0%      520B ± 0%   -30.85%  (p=0.000 n=10+10)
Unmarshal/*amqp.performClose-8            752B ± 0%      520B ± 0%   -30.85%  (p=0.000 n=10+10)
Unmarshal/*amqp.Message-8               3.25kB ± 0%    1.76kB ± 0%   -45.81%  (p=0.000 n=10+10)
Unmarshal/*amqp.MessageHeader-8           160B ± 0%      128B ± 0%   -20.00%  (p=0.000 n=10+10)
Unmarshal/*amqp.MessageProperties-8       304B ± 0%      208B ± 0%   -31.58%  (p=0.000 n=10+10)
Unmarshal/*amqp.stateReceived-8           192B ± 0%      112B ± 0%   -41.67%  (p=0.000 n=10+10)
Unmarshal/*amqp.stateAccepted-8           112B ± 0%      112B ± 0%      ~     (all equal)
Unmarshal/*amqp.stateRejected-8           752B ± 0%      520B ± 0%   -30.85%  (p=0.000 n=10+10)
Unmarshal/*amqp.stateReleased-8           112B ± 0%      112B ± 0%      ~     (all equal)
Unmarshal/*amqp.stateModified-8           600B ± 0%      480B ± 0%   -20.00%  (p=0.000 n=10+10)
Unmarshal/amqp.UUID-8                     128B ± 0%      128B ± 0%      ~     (all equal)
Unmarshal/amqp.lifetimePolicy-8           112B ± 0%      112B ± 0%      ~     (all equal)
Unmarshal/amqp.SenderSettleMode-8         112B ± 0%      112B ± 0%      ~     (all equal)
Unmarshal/amqp.ReceiverSettleMode-8       112B ± 0%      112B ± 0%      ~     (all equal)
Unmarshal/bool-8                          112B ± 0%      112B ± 0%      ~     (all equal)
Unmarshal/int8-8                          128B ± 0%      112B ± 0%   -12.50%  (p=0.000 n=10+10)
Unmarshal/int8#01-8                       128B ± 0%      112B ± 0%   -12.50%  (p=0.000 n=10+10)
Unmarshal/int16-8                         128B ± 0%      112B ± 0%   -12.50%  (p=0.000 n=10+10)
Unmarshal/int16#01-8                      128B ± 0%      112B ± 0%   -12.50%  (p=0.000 n=10+10)
Unmarshal/int32-8                         128B ± 0%      112B ± 0%   -12.50%  (p=0.000 n=10+10)
Unmarshal/int32#01-8                      128B ± 0%      112B ± 0%   -12.50%  (p=0.000 n=10+10)
Unmarshal/int64-8                         128B ± 0%      112B ± 0%   -12.50%  (p=0.000 n=10+10)
Unmarshal/int64#01-8                      128B ± 0%      112B ± 0%   -12.50%  (p=0.000 n=10+10)
Unmarshal/uint8-8                         112B ± 0%      112B ± 0%      ~     (all equal)
Unmarshal/uint16-8                        128B ± 0%      112B ± 0%   -12.50%  (p=0.000 n=10+10)
Unmarshal/uint32-8                        128B ± 0%      112B ± 0%   -12.50%  (p=0.000 n=10+10)
Unmarshal/uint64-8                        128B ± 0%      112B ± 0%   -12.50%  (p=0.000 n=10+10)
Unmarshal/amqp.describedType-8            248B ± 0%      184B ± 0%   -25.81%  (p=0.000 n=10+10)
Unmarshal/*amqp.saslInit-8                169B ± 0%      134B ± 0%   -20.71%  (p=0.000 n=10+10)
Unmarshal/*amqp.saslMechanisms-8          275B ± 0%      169B ± 0%   -38.55%  (p=0.000 n=10+10)
Unmarshal/*amqp.saslOutcome-8             176B ± 0%      144B ± 0%   -18.18%  (p=0.000 n=10+10)
Unmarshal/amqp.symbol-8                   128B ± 0%      120B ± 0%    -6.25%  (p=0.000 n=10+10)
Unmarshal/amqp.milliseconds-8             128B ± 0%      112B ± 0%   -12.50%  (p=0.000 n=10+10)
Unmarshal/*amqp.mapAnyAny-8               624B ± 0%      504B ± 0%   -19.23%  (p=0.000 n=10+10)
Unmarshal/*amqp.mapStringAny-8            602B ± 0%      500B ± 0%   -16.94%  (p=0.000 n=10+10)
Unmarshal/*amqp.mapSymbolAny-8            602B ± 0%      500B ± 0%   -16.94%  (p=0.000 n=10+10)

name                                  old allocs/op  new allocs/op  delta
FrameMarshal/transfer-8                   24.0 ± 0%       0.0       -100.00%  (p=0.000 n=10+10)
FrameUnmarshal/transfer-8                 22.0 ± 0%       8.0 ± 0%   -63.64%  (p=0.000 n=10+10)
Marshal/*amqp.performOpen-8               32.0 ± 0%       1.0 ± 0%   -96.88%  (p=0.000 n=10+10)
Marshal/*amqp.performBegin-8              29.0 ± 0%       1.0 ± 0%   -96.55%  (p=0.000 n=10+10)
Marshal/*amqp.performAttach-8             94.0 ± 0%       5.0 ± 0%   -94.68%  (p=0.000 n=10+10)
Marshal/amqp.role-8                       0.00           0.00           ~     (all equal)
Marshal/*amqp.unsettled-8                 6.00 ± 0%      1.00 ± 0%   -83.33%  (p=0.000 n=10+10)
Marshal/*amqp.source-8                    35.0 ± 0%       2.0 ± 0%   -94.29%  (p=0.000 n=10+10)
Marshal/*amqp.target-8                    22.0 ± 0%       1.0 ± 0%   -95.45%  (p=0.000 n=10+10)
Marshal/*amqp.performFlow-8               27.0 ± 0%       1.0 ± 0%   -96.30%  (p=0.000 n=10+10)
Marshal/*amqp.performTransfer-8           14.0 ± 0%       0.0       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.performDisposition-8        8.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.performDetach-8             26.0 ± 0%       2.0 ± 0%   -92.31%  (p=0.000 n=10+10)
Marshal/amqp.ErrorCondition-8             3.00 ± 0%      1.00 ± 0%   -66.67%  (p=0.000 n=10+10)
Marshal/*amqp.Error-8                     21.0 ± 0%       2.0 ± 0%   -90.48%  (p=0.000 n=10+10)
Marshal/*amqp.performEnd-8                23.0 ± 0%       2.0 ± 0%   -91.30%  (p=0.000 n=10+10)
Marshal/*amqp.performClose-8              23.0 ± 0%       2.0 ± 0%   -91.30%  (p=0.000 n=10+10)
Marshal/*amqp.Message-8                   81.0 ± 0%       5.0 ± 0%   -93.83%  (p=0.000 n=10+10)
Marshal/*amqp.MessageHeader-8             9.00 ± 0%      1.00 ± 0%   -88.89%  (p=0.000 n=10+10)
Marshal/*amqp.MessageProperties-8         39.0 ± 0%       0.0       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.stateReceived-8             7.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.stateAccepted-8             1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.stateRejected-8             23.0 ± 0%       2.0 ± 0%   -91.30%  (p=0.000 n=10+10)
Marshal/*amqp.stateReleased-8             1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.stateModified-8             9.00 ± 0%      1.00 ± 0%   -88.89%  (p=0.000 n=10+10)
Marshal/amqp.UUID-8                       1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Marshal/amqp.lifetimePolicy-8             1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/amqp.SenderSettleMode-8           1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/amqp.ReceiverSettleMode-8         1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/bool-8                            0.00           0.00           ~     (all equal)
Marshal/int8-8                            1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/int8#01-8                         1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/int16-8                           2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/int16#01-8                        2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/int32-8                           2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/int32#01-8                        2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/int64-8                           2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/int64#01-8                        2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/uint8-8                           1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/uint16-8                          2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/uint32-8                          2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/uint64-8                          2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/amqp.describedType-8              5.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.saslInit-8                  11.0 ± 0%       0.0       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.saslMechanisms-8            7.00 ± 0%      1.00 ± 0%   -85.71%  (p=0.000 n=10+10)
Marshal/*amqp.saslOutcome-8               6.00 ± 0%      1.00 ± 0%   -83.33%  (p=0.000 n=10+10)
Marshal/amqp.symbol-8                     2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/amqp.milliseconds-8               3.00 ± 0%      1.00 ± 0%   -66.67%  (p=0.000 n=10+10)
Marshal/*amqp.mapAnyAny-8                 6.00 ± 0%      1.00 ± 0%   -83.33%  (p=0.000 n=10+10)
Marshal/*amqp.mapStringAny-8              7.00 ± 0%      1.00 ± 0%   -85.71%  (p=0.000 n=10+10)
Marshal/*amqp.mapSymbolAny-8              7.00 ± 0%      1.00 ± 0%   -85.71%  (p=0.000 n=10+10)
Unmarshal/*amqp.performOpen-8             37.0 ± 0%      17.0 ± 0%   -54.05%  (p=0.000 n=10+10)
Unmarshal/*amqp.performBegin-8            33.0 ± 0%      10.0 ± 0%   -69.70%  (p=0.000 n=10+10)
Unmarshal/*amqp.performAttach-8            103 ± 0%        42 ± 0%   -59.22%  (p=0.000 n=10+10)
Unmarshal/amqp.role-8                     1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/*amqp.unsettled-8               11.0 ± 0%       5.0 ± 0%   -54.55%  (p=0.000 n=10+10)
Unmarshal/*amqp.source-8                  39.0 ± 0%      19.0 ± 0%   -51.28%  (p=0.000 n=10+10)
Unmarshal/*amqp.target-8                  22.0 ± 0%      11.0 ± 0%   -50.00%  (p=0.000 n=10+10)
Unmarshal/*amqp.performFlow-8             32.0 ± 0%       5.0 ± 0%   -84.38%  (p=0.000 n=10+10)
Unmarshal/*amqp.performTransfer-8         12.0 ± 0%       4.0 ± 0%   -66.67%  (p=0.000 n=10+10)
Unmarshal/*amqp.performDisposition-8      8.00 ± 0%      1.00 ± 0%   -87.50%  (p=0.000 n=10+10)
Unmarshal/*amqp.performDetach-8           28.0 ± 0%      10.0 ± 0%   -64.29%  (p=0.000 n=10+10)
Unmarshal/amqp.ErrorCondition-8           3.00 ± 0%      2.00 ± 0%   -33.33%  (p=0.000 n=10+10)
Unmarshal/*amqp.Error-8                   25.0 ± 0%      10.0 ± 0%   -60.00%  (p=0.000 n=10+10)
Unmarshal/*amqp.performEnd-8              25.0 ± 0%      10.0 ± 0%   -60.00%  (p=0.000 n=10+10)
Unmarshal/*amqp.performClose-8            25.0 ± 0%      10.0 ± 0%   -60.00%  (p=0.000 n=10+10)
Unmarshal/*amqp.Message-8                 94.0 ± 0%      36.0 ± 0%   -61.70%  (p=0.000 n=10+10)
Unmarshal/*amqp.MessageHeader-8           5.00 ± 0%      2.00 ± 0%   -60.00%  (p=0.000 n=10+10)
Unmarshal/*amqp.MessageProperties-8       28.0 ± 0%      12.0 ± 0%   -57.14%  (p=0.000 n=10+10)
Unmarshal/*amqp.stateReceived-8           5.00 ± 0%      1.00 ± 0%   -80.00%  (p=0.000 n=10+10)
Unmarshal/*amqp.stateAccepted-8           1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/*amqp.stateRejected-8           25.0 ± 0%      10.0 ± 0%   -60.00%  (p=0.000 n=10+10)
Unmarshal/*amqp.stateReleased-8           1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/*amqp.stateModified-8           13.0 ± 0%       6.0 ± 0%   -53.85%  (p=0.000 n=10+10)
Unmarshal/amqp.UUID-8                     2.00 ± 0%      2.00 ± 0%      ~     (all equal)
Unmarshal/amqp.lifetimePolicy-8           1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/amqp.SenderSettleMode-8         1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/amqp.ReceiverSettleMode-8       1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/bool-8                          1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/int8-8                          3.00 ± 0%      1.00 ± 0%   -66.67%  (p=0.000 n=10+10)
Unmarshal/int8#01-8                       3.00 ± 0%      1.00 ± 0%   -66.67%  (p=0.000 n=10+10)
Unmarshal/int16-8                         3.00 ± 0%      1.00 ± 0%   -66.67%  (p=0.000 n=10+10)
Unmarshal/int16#01-8                      3.00 ± 0%      1.00 ± 0%   -66.67%  (p=0.000 n=10+10)
Unmarshal/int32-8                         3.00 ± 0%      1.00 ± 0%   -66.67%  (p=0.000 n=10+10)
Unmarshal/int32#01-8                      3.00 ± 0%      1.00 ± 0%   -66.67%  (p=0.000 n=10+10)
Unmarshal/int64-8                         3.00 ± 0%      1.00 ± 0%   -66.67%  (p=0.000 n=10+10)
Unmarshal/int64#01-8                      3.00 ± 0%      1.00 ± 0%   -66.67%  (p=0.000 n=10+10)
Unmarshal/uint8-8                         1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/uint16-8                        3.00 ± 0%      1.00 ± 0%   -66.67%  (p=0.000 n=10+10)
Unmarshal/uint32-8                        3.00 ± 0%      1.00 ± 0%   -66.67%  (p=0.000 n=10+10)
Unmarshal/uint64-8                        3.00 ± 0%      1.00 ± 0%   -66.67%  (p=0.000 n=10+10)
Unmarshal/amqp.describedType-8            7.00 ± 0%      4.00 ± 0%   -42.86%  (p=0.000 n=10+10)
Unmarshal/*amqp.saslInit-8                7.00 ± 0%      4.00 ± 0%   -42.86%  (p=0.000 n=10+10)
Unmarshal/*amqp.saslMechanisms-8          11.0 ± 0%       5.0 ± 0%   -54.55%  (p=0.000 n=10+10)
Unmarshal/*amqp.saslOutcome-8             3.00 ± 0%      2.00 ± 0%   -33.33%  (p=0.000 n=10+10)
Unmarshal/amqp.symbol-8                   3.00 ± 0%      2.00 ± 0%   -33.33%  (p=0.000 n=10+10)
Unmarshal/amqp.milliseconds-8             4.00 ± 0%      1.00 ± 0%   -75.00%  (p=0.000 n=10+10)
Unmarshal/*amqp.mapAnyAny-8               13.0 ± 0%       6.0 ± 0%   -53.85%  (p=0.000 n=10+10)
Unmarshal/*amqp.mapStringAny-8            12.0 ± 0%       6.0 ± 0%   -50.00%  (p=0.000 n=10+10)
Unmarshal/*amqp.mapSymbolAny-8            12.0 ± 0%       6.0 ± 0%   -50.00%  (p=0.000 n=10+10)
```