### PR TITLE
Additional encoding/decoding optimization

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -1,0 +1,157 @@
+package amqp
+
+import (
+	"encoding/binary"
+	"io"
+)
+
+// buffer is similar to bytes.Buffer but specialized for this package
+type buffer struct {
+	b []byte
+	i int
+}
+
+func (b *buffer) next(n int) ([]byte, bool) {
+	if b.readCheck(n) {
+		buf := b.b[b.i:len(b.b)]
+		b.i = len(b.b)
+		return buf, false
+	}
+
+	buf := b.b[b.i : b.i+n]
+	b.i += n
+	return buf, true
+}
+
+func (b *buffer) skip(n int) {
+	b.i += n
+}
+
+func (b *buffer) reset() {
+	b.b = b.b[:0]
+	b.i = 0
+}
+
+func (b *buffer) readCheck(n int) bool {
+	return b.i+n > len(b.b)
+}
+
+func (b *buffer) readByte() (byte, error) {
+	if b.readCheck(1) {
+		return 0, io.EOF
+	}
+
+	byte_ := b.b[b.i]
+	b.i++
+	return byte_, nil
+}
+
+func (b *buffer) readType() (amqpType, error) {
+	n, err := b.readByte()
+	return amqpType(n), err
+}
+
+func (b *buffer) peekType() (amqpType, error) {
+	if b.readCheck(1) {
+		return 0, io.EOF
+	}
+
+	return amqpType(b.b[b.i]), nil
+}
+
+func (b *buffer) readUint16() (uint16, error) {
+	if b.readCheck(2) {
+		return 0, io.EOF
+	}
+
+	n := binary.BigEndian.Uint16(b.b[b.i:])
+	b.i += 2
+	return n, nil
+}
+
+func (b *buffer) readUint32() (uint32, error) {
+	if b.readCheck(4) {
+		return 0, io.EOF
+	}
+
+	n := binary.BigEndian.Uint32(b.b[b.i:])
+	b.i += 4
+	return n, nil
+}
+
+func (b *buffer) readUint64() (uint64, error) {
+	if b.readCheck(8) {
+		return 0, io.EOF
+	}
+
+	n := binary.BigEndian.Uint64(b.b[b.i : b.i+8])
+	b.i += 8
+	return n, nil
+}
+
+func (b *buffer) readFromOnce(r io.Reader) error {
+	const minRead = 512
+
+	l := len(b.b)
+	if cap(b.b)-l < minRead {
+		new := make([]byte, l, l+minRead)
+		copy(new, b.b)
+		b.b = new
+	}
+
+	n, err := r.Read(b.b[l:cap(b.b)])
+	b.b = b.b[:l+n]
+	if err != nil && err != io.EOF {
+		return err
+	}
+	return nil
+}
+
+func (b *buffer) write(p []byte) {
+	b.b = append(b.b, p...)
+}
+
+func (b *buffer) writeByte(byte_ byte) {
+	b.b = append(b.b, byte_)
+}
+
+func (b *buffer) writeString(s string) {
+	b.b = append(b.b, s...)
+}
+
+func (b *buffer) len() int {
+	return len(b.b) - b.i
+}
+
+func (b *buffer) bytes() []byte {
+	return b.b[b.i:]
+}
+
+func (b *buffer) writeUint16(n uint16) {
+	b.b = append(b.b,
+		byte(n>>8),
+		byte(n),
+	)
+}
+
+func (b *buffer) writeUint32(n uint32) {
+	b.b = append(b.b,
+		byte(n>>24),
+		byte(n>>16),
+		byte(n>>8),
+		byte(n),
+	)
+}
+
+func (b *buffer) writeUint64(n uint64) {
+	b.b = append(b.b,
+		byte(n>>56),
+		byte(n>>48),
+		byte(n>>40),
+		byte(n>>32),
+		byte(n>>24),
+		byte(n>>16),
+		byte(n>>8),
+		byte(n),
+	)
+}

--- a/encode.go
+++ b/encode.go
@@ -1,56 +1,35 @@
 package amqp
 
 import (
-	"bytes"
 	"encoding/binary"
-	"io"
 	"math"
 	"time"
 	"unicode/utf8"
 )
 
-// writer is the required interface for marshaling AMQP encoded data.
-type writer interface {
-	io.Writer
-	io.ByteWriter
-	WriteString(s string) (n int, err error)
-	Len() int
-	Bytes() []byte
-}
-
 // writesFrame encodes fr into buf.
-func writeFrame(buf *bytes.Buffer, fr frame) error {
+func writeFrame(buf *buffer, fr frame) error {
 	// write header
-	_, err := buf.Write([]byte{0, 0, 0, 0}) // size, overwrite later
-	if err != nil {
-		return err
-	}
-	err = buf.WriteByte(2) // doff, see frameHeader.DataOffset comment
-	if err != nil {
-		return err
-	}
-	err = buf.WriteByte(fr.typ) // frame type
-	if err != nil {
-		return err
-	}
-	err = binaryWriteUint16(buf, fr.channel) // channel
-	if err != nil {
-		return err
-	}
+	buf.write([]byte{
+		0, 0, 0, 0, // size, overwrite later
+		2,        // doff, see frameHeader.DataOffset comment
+		fr.type_, // frame type
+	})
+	buf.writeUint16(fr.channel) // channel
 
 	// write AMQP frame body
-	err = marshal(buf, fr.body)
+	err := marshal(buf, fr.body)
 	if err != nil {
 		return err
 	}
 
 	// validate size
-	if buf.Len() > math.MaxUint32 {
+	if buf.len() > math.MaxUint32 {
 		return errorNew("frame too large")
 	}
 
 	// retrieve raw bytes
-	bufBytes := buf.Bytes()
+	bufBytes := buf.bytes()
 
 	// write correct size
 	binary.BigEndian.PutUint32(bufBytes, uint32(len(bufBytes)))
@@ -58,364 +37,263 @@ func writeFrame(buf *bytes.Buffer, fr frame) error {
 }
 
 type marshaler interface {
-	marshal(writer) error
+	marshal(*buffer) error
 }
 
-func marshal(wr writer, i interface{}) error {
-	var err error
+func marshal(wr *buffer, i interface{}) error {
 	switch t := i.(type) {
-	case marshaler:
-		return t.marshal(wr)
 	case bool:
 		if t {
-			err = wr.WriteByte(byte(typeCodeBoolTrue))
+			wr.writeByte(byte(typeCodeBoolTrue))
 		} else {
-			err = wr.WriteByte(byte(typeCodeBoolFalse))
+			wr.writeByte(byte(typeCodeBoolFalse))
 		}
 	case *bool:
 		if *t {
-			err = wr.WriteByte(byte(typeCodeBoolTrue))
+			wr.writeByte(byte(typeCodeBoolTrue))
 		} else {
-			err = wr.WriteByte(byte(typeCodeBoolFalse))
+			wr.writeByte(byte(typeCodeBoolFalse))
 		}
 	case uint:
-		return writeUint64(wr, uint64(t))
+		writeUint64(wr, uint64(t))
 	case *uint:
-		return writeUint64(wr, uint64(*t))
+		writeUint64(wr, uint64(*t))
 	case uint64:
-		return writeUint64(wr, t)
+		writeUint64(wr, t)
 	case *uint64:
-		return writeUint64(wr, *t)
+		writeUint64(wr, *t)
 	case uint32:
-		return writeUint32(wr, t)
+		writeUint32(wr, t)
 	case *uint32:
-		if t == nil {
-			err = wr.WriteByte(byte(typeCodeNull))
-			break
-		}
-		return writeUint32(wr, *t)
+		writeUint32(wr, *t)
 	case uint16:
-		err = wr.WriteByte(byte(typeCodeUshort))
-		if err != nil {
-			return err
-		}
-		err = binaryWriteUint16(wr, t)
+		wr.writeByte(byte(typeCodeUshort))
+		wr.writeUint16(t)
 	case *uint16:
-		err = wr.WriteByte(byte(typeCodeUshort))
-		if err != nil {
-			return err
-		}
-		err = binaryWriteUint16(wr, *t)
+		wr.writeByte(byte(typeCodeUshort))
+		wr.writeUint16(*t)
 	case uint8:
-		err = wr.WriteByte(byte(typeCodeUbyte))
-		if err != nil {
-			return err
-		}
-		err = wr.WriteByte(t)
+		wr.write([]byte{
+			byte(typeCodeUbyte),
+			t,
+		})
 	case *uint8:
-		err = wr.WriteByte(byte(typeCodeUbyte))
-		if err != nil {
-			return err
-		}
-		err = wr.WriteByte(*t)
+		wr.write([]byte{
+			byte(typeCodeUbyte),
+			*t,
+		})
 	case int:
-		return writeInt64(wr, int64(t))
+		writeInt64(wr, int64(t))
 	case *int:
-		return writeInt64(wr, int64(*t))
+		writeInt64(wr, int64(*t))
 	case int8:
-		err = wr.WriteByte(byte(typeCodeByte))
-		if err != nil {
-			return err
-		}
-		err = wr.WriteByte(uint8(t))
+		wr.write([]byte{
+			byte(typeCodeByte),
+			uint8(t),
+		})
 	case *int8:
-		err = wr.WriteByte(byte(typeCodeByte))
-		if err != nil {
-			return err
-		}
-		err = wr.WriteByte(uint8(*t))
+		wr.write([]byte{
+			byte(typeCodeByte),
+			uint8(*t),
+		})
 	case int16:
-		err = wr.WriteByte(byte(typeCodeShort))
-		if err != nil {
-			return err
-		}
-		err = binaryWriteUint16(wr, uint16(t))
+		wr.writeByte(byte(typeCodeShort))
+		wr.writeUint16(uint16(t))
 	case *int16:
-		err = wr.WriteByte(byte(typeCodeShort))
-		if err != nil {
-			return err
-		}
-		err = binaryWriteUint16(wr, uint16(*t))
+		wr.writeByte(byte(typeCodeShort))
+		wr.writeUint16(uint16(*t))
 	case int32:
-		return writeInt32(wr, t)
+		writeInt32(wr, t)
 	case *int32:
-		return writeInt32(wr, *t)
+		writeInt32(wr, *t)
 	case int64:
-		return writeInt64(wr, t)
+		writeInt64(wr, t)
 	case *int64:
-		return writeInt64(wr, *t)
+		writeInt64(wr, *t)
 	case float32:
-		return writeFloat(wr, t)
+		writeFloat(wr, t)
 	case *float32:
-		return writeFloat(wr, *t)
+		writeFloat(wr, *t)
 	case float64:
-		return writeDouble(wr, t)
+		writeDouble(wr, t)
 	case *float64:
-		return writeDouble(wr, *t)
+		writeDouble(wr, *t)
 	case string:
-		err = writeString(wr, t)
+		return writeString(wr, t)
 	case *string:
-		err = writeString(wr, *t)
+		return writeString(wr, *t)
 	case []byte:
-		err = writeBinary(wr, t)
+		return writeBinary(wr, t)
 	case *[]byte:
-		err = writeBinary(wr, *t)
+		return writeBinary(wr, *t)
 	case map[interface{}]interface{}:
-		err = writeMap(wr, t)
+		return writeMap(wr, t)
 	case *map[interface{}]interface{}:
-		err = writeMap(wr, *t)
+		return writeMap(wr, *t)
 	case map[string]interface{}:
-		err = writeMap(wr, t)
+		return writeMap(wr, t)
 	case *map[string]interface{}:
-		err = writeMap(wr, *t)
+		return writeMap(wr, *t)
 	case map[symbol]interface{}:
-		err = writeMap(wr, t)
+		return writeMap(wr, t)
 	case *map[symbol]interface{}:
-		err = writeMap(wr, *t)
+		return writeMap(wr, *t)
 	case unsettled:
-		err = writeMap(wr, t)
+		return writeMap(wr, t)
 	case *unsettled:
-		err = writeMap(wr, *t)
+		return writeMap(wr, *t)
 	case time.Time:
-		err = writeTimestamp(wr, t)
+		writeTimestamp(wr, t)
 	case *time.Time:
-		err = writeTimestamp(wr, *t)
+		writeTimestamp(wr, *t)
 	case []int8:
-		err = arrayInt8(t).marshal(wr)
+		return arrayInt8(t).marshal(wr)
 	case *[]int8:
-		err = arrayInt8(*t).marshal(wr)
+		return arrayInt8(*t).marshal(wr)
 	case []uint16:
-		err = arrayUint16(t).marshal(wr)
+		return arrayUint16(t).marshal(wr)
 	case *[]uint16:
-		err = arrayUint16(*t).marshal(wr)
+		return arrayUint16(*t).marshal(wr)
 	case []int16:
-		err = arrayInt16(t).marshal(wr)
+		return arrayInt16(t).marshal(wr)
 	case *[]int16:
-		err = arrayInt16(*t).marshal(wr)
+		return arrayInt16(*t).marshal(wr)
 	case []uint32:
-		err = arrayUint32(t).marshal(wr)
+		return arrayUint32(t).marshal(wr)
 	case *[]uint32:
-		err = arrayUint32(*t).marshal(wr)
+		return arrayUint32(*t).marshal(wr)
 	case []int32:
-		err = arrayInt32(t).marshal(wr)
+		return arrayInt32(t).marshal(wr)
 	case *[]int32:
-		err = arrayInt32(*t).marshal(wr)
+		return arrayInt32(*t).marshal(wr)
 	case []uint64:
-		err = arrayUint64(t).marshal(wr)
+		return arrayUint64(t).marshal(wr)
 	case *[]uint64:
-		err = arrayUint64(*t).marshal(wr)
+		return arrayUint64(*t).marshal(wr)
 	case []int64:
-		err = arrayInt64(t).marshal(wr)
+		return arrayInt64(t).marshal(wr)
 	case *[]int64:
-		err = arrayInt64(*t).marshal(wr)
+		return arrayInt64(*t).marshal(wr)
 	case []float32:
-		err = arrayFloat(t).marshal(wr)
+		return arrayFloat(t).marshal(wr)
 	case *[]float32:
-		err = arrayFloat(*t).marshal(wr)
+		return arrayFloat(*t).marshal(wr)
 	case []float64:
-		err = arrayDouble(t).marshal(wr)
+		return arrayDouble(t).marshal(wr)
 	case *[]float64:
-		err = arrayDouble(*t).marshal(wr)
+		return arrayDouble(*t).marshal(wr)
 	case []bool:
-		err = arrayBool(t).marshal(wr)
+		return arrayBool(t).marshal(wr)
 	case *[]bool:
-		err = arrayBool(*t).marshal(wr)
+		return arrayBool(*t).marshal(wr)
 	case []string:
-		err = arrayString(t).marshal(wr)
+		return arrayString(t).marshal(wr)
 	case *[]string:
-		err = arrayString(*t).marshal(wr)
+		return arrayString(*t).marshal(wr)
 	case []symbol:
-		err = arraySymbol(t).marshal(wr)
+		return arraySymbol(t).marshal(wr)
 	case *[]symbol:
-		err = arraySymbol(*t).marshal(wr)
+		return arraySymbol(*t).marshal(wr)
 	case [][]byte:
-		err = arrayBinary(t).marshal(wr)
+		return arrayBinary(t).marshal(wr)
 	case *[][]byte:
-		err = arrayBinary(*t).marshal(wr)
+		return arrayBinary(*t).marshal(wr)
 	case []time.Time:
-		err = arrayTimestamp(t).marshal(wr)
+		return arrayTimestamp(t).marshal(wr)
 	case *[]time.Time:
-		err = arrayTimestamp(*t).marshal(wr)
+		return arrayTimestamp(*t).marshal(wr)
 	case []UUID:
-		err = arrayUUID(t).marshal(wr)
+		return arrayUUID(t).marshal(wr)
 	case *[]UUID:
-		err = arrayUUID(*t).marshal(wr)
+		return arrayUUID(*t).marshal(wr)
 	case []interface{}:
-		err = list(t).marshal(wr)
+		return list(t).marshal(wr)
 	case *[]interface{}:
-		err = list(*t).marshal(wr)
+		return list(*t).marshal(wr)
+	case marshaler:
+		return t.marshal(wr)
 	default:
 		return errorErrorf("marshal not implemented for %T", i)
 	}
-	return err
+	return nil
 }
 
-func writeInt32(wr writer, n int32) error {
+func writeInt32(wr *buffer, n int32) {
 	if n < 128 && n >= -128 {
-		err := wr.WriteByte(byte(typeCodeSmallint))
-		if err != nil {
-			return err
-		}
-		return wr.WriteByte(byte(n))
+		wr.write([]byte{
+			byte(typeCodeSmallint),
+			byte(n),
+		})
+		return
 	}
 
-	err := wr.WriteByte(byte(typeCodeInt))
-	if err != nil {
-		return err
-	}
-
-	return binaryWriteUint32(wr, uint32(n))
+	wr.writeByte(byte(typeCodeInt))
+	wr.writeUint32(uint32(n))
 }
 
-func binaryWriteUint16(wr writer, n uint16) error {
-	err := wr.WriteByte(byte(n >> 8))
-	if err != nil {
-		return err
-	}
-	return wr.WriteByte(byte(n))
-}
-
-func binaryWriteUint32(wr writer, n uint32) error {
-	err := wr.WriteByte(byte(n >> 24))
-	if err != nil {
-		return err
-	}
-	err = wr.WriteByte(byte(n >> 16))
-	if err != nil {
-		return err
-	}
-	err = wr.WriteByte(byte(n >> 8))
-	if err != nil {
-		return err
-	}
-	return wr.WriteByte(byte(n))
-}
-
-func binaryWriteUint64(wr writer, n uint64) error {
-	err := wr.WriteByte(byte(n >> 56))
-	if err != nil {
-		return err
-	}
-	err = wr.WriteByte(byte(n >> 48))
-	if err != nil {
-		return err
-	}
-	err = wr.WriteByte(byte(n >> 40))
-	if err != nil {
-		return err
-	}
-	err = wr.WriteByte(byte(n >> 32))
-	if err != nil {
-		return err
-	}
-	err = wr.WriteByte(byte(n >> 24))
-	if err != nil {
-		return err
-	}
-	err = wr.WriteByte(byte(n >> 16))
-	if err != nil {
-		return err
-	}
-	err = wr.WriteByte(byte(n >> 8))
-	if err != nil {
-		return err
-	}
-	return wr.WriteByte(byte(n))
-}
-
-func writeInt64(wr writer, n int64) error {
+func writeInt64(wr *buffer, n int64) {
 	if n < 128 && n >= -128 {
-		err := wr.WriteByte(byte(typeCodeSmalllong))
-		if err != nil {
-			return err
-		}
-		return wr.WriteByte(byte(n))
+		wr.write([]byte{
+			byte(typeCodeSmalllong),
+			byte(n),
+		})
+		return
 	}
 
-	err := wr.WriteByte(byte(typeCodeLong))
-	if err != nil {
-		return err
-	}
-	err = binaryWriteUint64(wr, uint64(n))
-	return err
+	wr.writeByte(byte(typeCodeLong))
+	wr.writeUint64(uint64(n))
 }
 
-func writeUint32(wr writer, n uint32) error {
+func writeUint32(wr *buffer, n uint32) {
 	if n == 0 {
-		return wr.WriteByte(byte(typeCodeUint0))
+		wr.writeByte(byte(typeCodeUint0))
+		return
 	}
 
 	if n < 256 {
-		err := wr.WriteByte(byte(typeCodeSmallUint))
-		if err != nil {
-			return err
-		}
-		return wr.WriteByte(byte(n))
+		wr.write([]byte{
+			byte(typeCodeSmallUint),
+			byte(n),
+		})
+		return
 	}
 
-	err := wr.WriteByte(byte(typeCodeUint))
-	if err != nil {
-		return err
-	}
-	return binaryWriteUint32(wr, n)
+	wr.writeByte(byte(typeCodeUint))
+	wr.writeUint32(n)
 }
 
-func writeUint64(wr writer, n uint64) error {
+func writeUint64(wr *buffer, n uint64) {
 	if n == 0 {
-		return wr.WriteByte(byte(typeCodeUlong0))
+		wr.writeByte(byte(typeCodeUlong0))
+		return
 	}
 
 	if n < 256 {
-		err := wr.WriteByte(byte(typeCodeSmallUlong))
-		if err != nil {
-			return err
-		}
-		err = wr.WriteByte(byte(n))
-		return err
+		wr.write([]byte{
+			byte(typeCodeSmallUlong),
+			byte(n),
+		})
+		return
 	}
 
-	err := wr.WriteByte(byte(typeCodeUlong))
-	if err != nil {
-		return err
-	}
-
-	return binaryWriteUint64(wr, n)
+	wr.writeByte(byte(typeCodeUlong))
+	wr.writeUint64(n)
 }
 
-func writeFloat(wr writer, f float32) error {
-	err := wr.WriteByte(byte(typeCodeFloat))
-	if err != nil {
-		return err
-	}
-	return binaryWriteUint32(wr, math.Float32bits(f))
+func writeFloat(wr *buffer, f float32) {
+	wr.writeByte(byte(typeCodeFloat))
+	wr.writeUint32(math.Float32bits(f))
 }
 
-func writeDouble(wr writer, f float64) error {
-	err := wr.WriteByte(byte(typeCodeDouble))
-	if err != nil {
-		return err
-	}
-	return binaryWriteUint64(wr, math.Float64bits(f))
+func writeDouble(wr *buffer, f float64) {
+	wr.writeByte(byte(typeCodeDouble))
+	wr.writeUint64(math.Float64bits(f))
 }
 
-func writeTimestamp(wr writer, t time.Time) error {
-	err := wr.WriteByte(byte(typeCodeTimestamp))
-	if err != nil {
-		return err
-	}
-
+func writeTimestamp(wr *buffer, t time.Time) {
+	wr.writeByte(byte(typeCodeTimestamp))
 	ms := t.UnixNano() / int64(time.Millisecond)
-	return binaryWriteUint64(wr, uint64(ms))
+	wr.writeUint64(uint64(ms))
 }
 
 // marshalField is a field to be marshaled
@@ -429,7 +307,7 @@ type marshalField struct {
 // The returned bytes include the composite header and fields. Fields with
 // omit set to true will be encoded as null or omitted altogether if there are
 // no non-null fields after them.
-func marshalComposite(wr writer, code amqpType, fields ...marshalField) error {
+func marshalComposite(wr *buffer, code amqpType, fields []marshalField) error {
 	// lastSetIdx is the last index to have a non-omitted field.
 	// start at -1 as it's possible to have no fields in a composite
 	lastSetIdx := -1
@@ -445,52 +323,33 @@ func marshalComposite(wr writer, code amqpType, fields ...marshalField) error {
 
 	// write header only
 	if lastSetIdx == -1 {
-		err := wr.WriteByte(0x0)
-		if err != nil {
-			return err
-		}
-		err = wr.WriteByte(byte(typeCodeSmallUlong))
-		if err != nil {
-			return err
-		}
-		err = wr.WriteByte(byte(code))
-		if err != nil {
-			return err
-		}
-		err = wr.WriteByte(byte(typeCodeList0))
-		return err
+		wr.write([]byte{
+			0x0,
+			byte(typeCodeSmallUlong),
+			byte(code),
+			byte(typeCodeList0),
+		})
+		return nil
 	}
 
 	// write header
-	err := writeDescriptor(wr, code)
-	if err != nil {
-		return err
-	}
+	writeDescriptor(wr, code)
 
 	// write fields
-	err = wr.WriteByte(byte(typeCodeList32))
-	if err != nil {
-		return err
-	}
+	wr.writeByte(byte(typeCodeList32))
 
 	// write temp size, replace later
-	sizeIdx := wr.Len()
-	err = binaryWriteUint32(wr, 0)
-	if err != nil {
-		return err
-	}
-	preFieldLen := wr.Len()
+	sizeIdx := wr.len()
+	wr.write([]byte{0, 0, 0, 0})
+	preFieldLen := wr.len()
 
 	// field count
-	err = binaryWriteUint32(wr, uint32(lastSetIdx+1))
-	if err != nil {
-		return err
-	}
+	wr.writeUint32(uint32(lastSetIdx + 1))
 
 	// write null to each index up to lastSetIdx
 	for _, f := range fields[:lastSetIdx+1] {
 		if f.omit {
-			wr.WriteByte(byte(typeCodeNull))
+			wr.writeByte(byte(typeCodeNull))
 			continue
 		}
 		err := marshal(wr, f.value)
@@ -500,26 +359,22 @@ func marshalComposite(wr writer, code amqpType, fields ...marshalField) error {
 	}
 
 	// fix size
-	size := uint32(wr.Len() - preFieldLen)
-	buf := wr.Bytes()
+	size := uint32(wr.len() - preFieldLen)
+	buf := wr.bytes()
 	binary.BigEndian.PutUint32(buf[sizeIdx:], size)
 
-	return err
+	return nil
 }
 
-func writeDescriptor(wr writer, code amqpType) error {
-	err := wr.WriteByte(0x0)
-	if err != nil {
-		return err
-	}
-	err = wr.WriteByte(byte(typeCodeSmallUlong))
-	if err != nil {
-		return err
-	}
-	return wr.WriteByte(byte(code))
+func writeDescriptor(wr *buffer, code amqpType) {
+	wr.write([]byte{
+		0x0,
+		byte(typeCodeSmallUlong),
+		byte(code),
+	})
 }
 
-func writeString(wr writer, str string) error {
+func writeString(wr *buffer, str string) error {
 	if !utf8.ValidString(str) {
 		return errorNew("not a valid UTF-8 string")
 	}
@@ -528,201 +383,137 @@ func writeString(wr writer, str string) error {
 	switch {
 	// Str8
 	case l < 256:
-		err := wr.WriteByte(byte(typeCodeStr8))
-		if err != nil {
-			return err
-		}
-		err = wr.WriteByte(byte(l))
-		if err != nil {
-			return err
-		}
-		_, err = wr.WriteString(str)
-		return err
+		wr.write([]byte{
+			byte(typeCodeStr8),
+			byte(l),
+		})
+		wr.writeString(str)
+		return nil
 
 	// Str32
 	case l < math.MaxUint32:
-		err := wr.WriteByte(byte(typeCodeStr32))
-		if err != nil {
-			return err
-		}
-
-		err = binaryWriteUint32(wr, uint32(l))
-		if err != nil {
-			return err
-		}
-
-		_, err = wr.WriteString(str)
-		return err
+		wr.writeByte(byte(typeCodeStr32))
+		wr.writeUint32(uint32(l))
+		wr.writeString(str)
+		return nil
 
 	default:
 		return errorNew("too long")
 	}
 }
 
-func writeBinary(wr writer, bin []byte) error {
+func writeBinary(wr *buffer, bin []byte) error {
 	l := len(bin)
 
 	switch {
 	// List8
 	case l < 256:
-		err := wr.WriteByte(byte(typeCodeVbin8))
-		if err != nil {
-			return err
-		}
-		err = wr.WriteByte(uint8(l))
-		if err != nil {
-			return err
-		}
-		_, err = wr.Write(bin)
-		return err
+		wr.write([]byte{
+			byte(typeCodeVbin8),
+			byte(l),
+		})
+		wr.write(bin)
+		return nil
 
 	// List32
 	case l < math.MaxUint32:
-		err := wr.WriteByte(byte(typeCodeVbin32))
-		if err != nil {
-			return err
-		}
-
-		err = binaryWriteUint32(wr, uint32(l))
-		if err != nil {
-			return err
-		}
-
-		_, err = wr.Write(bin)
-		return err
+		wr.writeByte(byte(typeCodeVbin32))
+		wr.writeUint32(uint32(l))
+		wr.write(bin)
+		return nil
 
 	default:
 		return errorNew("too long")
 	}
 }
 
-func writeMap(wr writer, m interface{}) error {
-	var length int
-	buf := new(bytes.Buffer)
+func writeMap(wr *buffer, m interface{}) error {
+	startIdx := wr.len()
+	wr.write([]byte{
+		byte(typeCodeMap32), // type
+		0, 0, 0, 0,          // size placeholder
+		0, 0, 0, 0, // length placeholder
+	})
 
+	var pairs int
 	switch m := m.(type) {
 	case map[interface{}]interface{}:
-		length = len(m)
+		pairs = len(m) * 2
 		for key, val := range m {
-			err := marshal(buf, key)
+			err := marshal(wr, key)
 			if err != nil {
 				return err
 			}
-			err = marshal(buf, val)
+			err = marshal(wr, val)
 			if err != nil {
 				return err
 			}
 		}
 	case map[string]interface{}:
-		length = len(m)
+		pairs = len(m) * 2
 		for key, val := range m {
-			err := amqpString(key).marshal(buf)
-			if err != nil {
-				return err
-			}
-			err = marshal(buf, val)
+			writeString(wr, key)
+			err := marshal(wr, val)
 			if err != nil {
 				return err
 			}
 		}
 	case map[symbol]interface{}:
-		length = len(m)
+		pairs = len(m) * 2
 		for key, val := range m {
-			err := key.marshal(buf)
+			err := key.marshal(wr)
 			if err != nil {
 				return err
 			}
-			err = marshal(buf, val)
+			err = marshal(wr, val)
 			if err != nil {
 				return err
 			}
 		}
 	case unsettled:
-		length = len(m)
+		pairs = len(m) * 2
 		for key, val := range m {
-			err := amqpString(key).marshal(buf)
-			if err != nil {
-				return err
-			}
-			err = marshal(buf, val)
+			writeString(wr, key)
+			err := marshal(wr, val)
 			if err != nil {
 				return err
 			}
 		}
 	default:
-		return errorErrorf("unsupported type or map type %T", m)
+		return errorErrorf("unsupported map type %T", m)
 	}
 
-	pairs := length * 2
 	if pairs > math.MaxUint32-4 {
 		return errorNew("map contains too many elements")
 	}
 
-	l := buf.Len()
-	switch {
-	case l+1 <= math.MaxUint8:
-		_, err := wr.Write([]byte{byte(typeCodeMap8), byte(l + 1), byte(pairs)})
-		if err != nil {
-			return err
-		}
-	case l+4 <= math.MaxUint32:
-		err := wr.WriteByte(byte(typeCodeMap32))
-		if err != nil {
-			return err
-		}
-		err = binaryWriteUint32(wr, uint32(l+4))
-		if err != nil {
-			return err
-		}
-		err = binaryWriteUint32(wr, uint32(pairs))
-		if err != nil {
-			return err
-		}
-	default:
-		return errorNew("map too large")
-	}
+	// overwrite placeholder size and length
+	bytes := wr.bytes()[startIdx+1 : startIdx+9]
+	_ = bytes[7] // bounds check hint
 
-	_, err := buf.WriteTo(wr)
-	return err
+	length := wr.len() - startIdx - 1 - 4 // -1 for type, -4 for length
+	binary.BigEndian.PutUint32(bytes[:4], uint32(length))
+	binary.BigEndian.PutUint32(bytes[4:8], uint32(pairs))
+
+	return nil
 }
 
-func writeArrayHeader(wr writer, length, typeSize int, type_ amqpType) error {
+func writeArrayHeader(wr *buffer, length, typeSize int, type_ amqpType) {
 	size := length * typeSize
+
 	// array type
 	if size+array8TLSize <= math.MaxUint8 {
-		//type
-		err := wr.WriteByte(byte(typeCodeArray8))
-		if err != nil {
-			return err
-		}
-		// size
-		wr.WriteByte(byte(size + array8TLSize))
-		if err != nil {
-			return err
-		}
-		// length
-		wr.WriteByte(byte(length))
-		if err != nil {
-			return err
-		}
+		wr.write([]byte{
+			byte(typeCodeArray8),      // type
+			byte(size + array8TLSize), // size
+			byte(length),              // length
+		})
 	} else {
-		//type
-		err := wr.WriteByte(byte(typeCodeArray32))
-		if err != nil {
-			return err
-		}
-		// size
-		err = binaryWriteUint32(wr, uint32(size+array32TLSize))
-		if err != nil {
-			return err
-		}
-		// length
-		err = binaryWriteUint32(wr, uint32(length))
-		if err != nil {
-			return err
-		}
+		wr.writeByte(byte(typeCodeArray32))          //type
+		wr.writeUint32(uint32(size + array32TLSize)) // size
+		wr.writeUint32(uint32(length))               // length
 	}
 
 	// element type
-	return wr.WriteByte(byte(type_))
+	wr.writeByte(byte(type_))
 }

--- a/fuzz.go
+++ b/fuzz.go
@@ -3,7 +3,6 @@
 package amqp
 
 import (
-	"bytes"
 	"context"
 	"time"
 
@@ -181,8 +180,8 @@ func FuzzUnmarshal(data []byte) int {
 	}
 
 	for _, t := range types {
-		unmarshal(bytes.NewBuffer(data), t)
-		readAny(bytes.NewBuffer(data))
+		unmarshal(&buffer{b: data}, t)
+		readAny(&buffer{b: data})
 	}
 	return 0
 }

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -374,6 +374,9 @@ func TestFuzzMarshalCrashers(t *testing.T) {
 			"\x19foo description\xc1\x18\x04\xa1" +
 			"\x05other\xa1\x04info\xa1\x03andU\x00\x00" +
 			"\x03k",
+		17: "\xf0\x00\x00\x00\x01@\x00TRUE\x00",
+		18: "\xf0\x00\x00\x00\x00\x10RTRT",
+		19: "\x00p\x00inp\xf0\x00\x00\x00\x01p\x00inp",
 	}
 
 	for i, tt := range tests {

--- a/sasl.go
+++ b/sasl.go
@@ -17,12 +17,13 @@ const (
 
 type saslCode uint8
 
-func (s saslCode) marshal(wr writer) error {
+func (s saslCode) marshal(wr *buffer) error {
 	return marshal(wr, uint8(s))
 }
 
-func (s *saslCode) unmarshal(r reader) error {
-	_, err := unmarshal(r, (*uint8)(s))
+func (s *saslCode) unmarshal(r *buffer) error {
+	n, err := readUbyte(r)
+	*s = saslCode(n)
 	return err
 }
 
@@ -42,7 +43,7 @@ func ConnSASLPlain(username, password string) ConnOption {
 		c.saslHandlers[saslMechanismPLAIN] = func() stateFunc {
 			// send saslInit with PLAIN payload
 			c.err = c.writeFrame(frame{
-				typ: frameTypeSASL,
+				type_: frameTypeSASL,
 				body: &saslInit{
 					Mechanism:       "PLAIN",
 					InitialResponse: []byte("\x00" + username + "\x00" + password),
@@ -71,7 +72,7 @@ func ConnSASLAnonymous() ConnOption {
 		// add the handler the the map
 		c.saslHandlers[saslMechanismANONYMOUS] = func() stateFunc {
 			c.err = c.writeFrame(frame{
-				typ: frameTypeSASL,
+				type_: frameTypeSASL,
 				body: &saslInit{
 					Mechanism:       saslMechanismANONYMOUS,
 					InitialResponse: []byte("anonymous"),


### PR DESCRIPTION
* Replace reader/writer interfaces with concrete `buffer` type.
* Avoid intermediate buffer during map encoding.
* Avoid `milliseconds` marshal allocation.
* Remove `errNull`/`isNull` from marshal and avoid defer in hot path.
* Cleanup of decoding code.
* Minimize bounds checks by adding hints.
* Check interface types last in type switches.
* Add fastpath in unmarshal for `**uint32`.

Closes #17 

```
name                                       old time/op    new time/op    delta
FrameMarshal/transfer-8                       420ns ± 4%     197ns ± 5%   -53.04%  (p=0.000 n=10+10)
FrameUnmarshal/transfer-8                    1.84µs ± 0%    0.61µs ± 5%   -66.64%  (p=0.000 n=8+10)
Marshal/*amqp.performOpen-8                   787ns ± 3%     293ns ± 5%   -62.83%  (p=0.000 n=10+10)
Marshal/*amqp.performBegin-8                  621ns ± 1%     216ns ± 3%   -65.27%  (p=0.000 n=10+9)
Marshal/*amqp.performAttach-8                2.45µs ± 1%    1.12µs ± 3%   -54.13%  (p=0.000 n=10+10)
Marshal/amqp.role-8                          30.5ns ± 2%    20.5ns ± 2%   -32.75%  (p=0.000 n=10+10)
Marshal/*amqp.unsettled-8                     258ns ± 8%     100ns ± 3%   -61.10%  (p=0.000 n=10+9)
Marshal/*amqp.source-8                        900ns ± 1%     401ns ± 5%   -55.43%  (p=0.000 n=10+10)
Marshal/*amqp.target-8                        516ns ± 1%     244ns ± 3%   -52.79%  (p=0.000 n=10+10)
Marshal/*amqp.performFlow-8                   576ns ± 1%     193ns ± 4%   -66.42%  (p=0.000 n=10+10)
Marshal/*amqp.performTransfer-8               404ns ± 6%     184ns ± 2%   -54.35%  (p=0.000 n=10+10)
Marshal/*amqp.performDisposition-8            215ns ± 5%     102ns ± 4%   -52.54%  (p=0.000 n=10+10)
Marshal/*amqp.performDetach-8                 612ns ± 2%     279ns ± 0%   -54.37%  (p=0.000 n=10+6)
Marshal/*amqp.performDetach#01-8             1.23µs ± 8%    0.42µs ± 4%   -65.71%  (p=0.000 n=9+10)
Marshal/amqp.ErrorCondition-8                69.9ns ± 1%    27.3ns ± 4%   -60.96%  (p=0.000 n=10+10)
Marshal/*amqp.Error-8                         493ns ± 1%     221ns ± 5%   -55.12%  (p=0.000 n=10+10)
Marshal/*amqp.performEnd-8                    595ns ± 1%     264ns ± 3%   -55.69%  (p=0.000 n=8+10)
Marshal/*amqp.performClose-8                  601ns ± 2%     263ns ± 4%   -56.29%  (p=0.000 n=10+10)
Marshal/*amqp.Message-8                      1.83µs ± 0%    0.80µs ± 4%   -56.33%  (p=0.000 n=8+10)
Marshal/*amqp.MessageHeader-8                 194ns ± 2%      82ns ± 3%   -57.39%  (p=0.000 n=10+10)
Marshal/*amqp.MessageProperties-8             546ns ± 3%     264ns ± 5%   -51.56%  (p=0.000 n=8+10)
Marshal/*amqp.stateReceived-8                 137ns ± 3%      48ns ± 2%   -65.10%  (p=0.000 n=9+10)
Marshal/*amqp.stateAccepted-8                30.1ns ± 2%    21.4ns ± 4%   -28.80%  (p=0.000 n=8+10)
Marshal/*amqp.stateRejected-8                 608ns ± 1%     261ns ± 3%   -57.04%  (p=0.000 n=10+9)
Marshal/*amqp.stateReleased-8                30.6ns ± 5%    22.2ns ± 3%   -27.30%  (p=0.000 n=8+10)
Marshal/*amqp.stateModified-8                 352ns ± 4%     145ns ± 6%   -58.84%  (p=0.000 n=10+10)
Marshal/amqp.lifetimePolicy-8                29.9ns ± 3%    19.8ns ± 3%   -33.73%  (p=0.000 n=10+10)
Marshal/amqp.SenderSettleMode-8              35.1ns ± 3%    23.7ns ± 3%   -32.44%  (p=0.000 n=9+9)
Marshal/amqp.ReceiverSettleMode-8            36.3ns ±13%    23.6ns ± 4%   -35.07%  (p=0.000 n=10+10)
Marshal/*amqp.saslInit-8                      160ns ± 5%      90ns ± 4%   -43.69%  (p=0.000 n=8+10)
Marshal/*amqp.saslMechanisms-8                235ns ± 1%      74ns ± 7%   -68.69%  (p=0.000 n=10+10)
Marshal/*amqp.saslOutcome-8                   169ns ± 1%      71ns ± 9%   -57.88%  (p=0.000 n=10+10)
Marshal/amqp.milliseconds-8                  60.2ns ± 2%    19.0ns ± 5%   -68.40%  (p=0.000 n=10+10)
Marshal/amqp.symbol-8                        29.0ns ± 5%    25.1ns ± 5%   -13.40%  (p=0.000 n=10+10)
Marshal/map[amqp.symbol]interface_{}-8        242ns ± 9%      81ns ± 2%   -66.57%  (p=0.000 n=10+9)
Marshal/amqp.UUID-8                          46.4ns ± 2%    19.2ns ± 6%   -58.73%  (p=0.000 n=9+10)
Marshal/bool-8                               16.6ns ± 5%     6.2ns ± 4%   -62.82%  (p=0.000 n=10+10)
Marshal/int8-8                               19.4ns ± 1%     8.3ns ± 5%   -57.28%  (p=0.000 n=9+10)
Marshal/int8#01-8                            19.5ns ± 2%     8.4ns ± 4%   -57.10%  (p=0.000 n=9+10)
Marshal/int16-8                              24.3ns ± 6%     6.8ns ± 5%   -72.13%  (p=0.000 n=10+10)
Marshal/int16#01-8                           24.9ns ± 2%     7.0ns ± 6%   -71.90%  (p=0.000 n=9+10)
Marshal/int32-8                              33.1ns ± 2%     6.9ns ± 3%   -79.13%  (p=0.000 n=9+10)
Marshal/int32#01-8                           32.6ns ± 5%     6.9ns ± 5%   -78.94%  (p=0.000 n=10+10)
Marshal/int64-8                              45.8ns ± 4%     7.0ns ± 4%   -84.66%  (p=0.000 n=10+10)
Marshal/int64#01-8                           45.7ns ± 3%     7.1ns ± 5%   -84.54%  (p=0.000 n=8+10)
Marshal/uint8-8                              19.0ns ± 2%     8.3ns ± 5%   -56.49%  (p=0.000 n=9+10)
Marshal/uint16-8                             24.8ns ± 4%     7.4ns ± 2%   -70.23%  (p=0.000 n=10+9)
Marshal/uint32-8                             33.4ns ± 3%     7.1ns ± 5%   -78.78%  (p=0.000 n=8+10)
Marshal/uint64-8                             46.5ns ± 3%     8.5ns ± 4%   -81.78%  (p=0.000 n=9+10)
Marshal/float32-8                            33.7ns ± 7%     7.2ns ± 6%   -78.73%  (p=0.000 n=10+10)
Marshal/float32#01-8                         33.5ns ± 3%     7.1ns ± 5%   -78.89%  (p=0.000 n=10+10)
Marshal/float32#02-8                         33.4ns ± 5%     7.0ns ± 5%   -78.99%  (p=0.000 n=10+10)
Marshal/float32#03-8                         34.1ns ± 6%     7.2ns ± 4%   -78.86%  (p=0.000 n=10+10)
Marshal/float64-8                            47.3ns ± 3%     7.4ns ± 4%   -84.38%  (p=0.000 n=9+10)
Marshal/float64#01-8                         47.3ns ± 3%     7.4ns ± 6%   -84.37%  (p=0.000 n=8+10)
Marshal/float64#02-8                         46.9ns ± 5%     7.6ns ± 1%   -83.87%  (p=0.000 n=10+10)
Marshal/float64#03-8                         47.6ns ± 4%     7.3ns ± 4%   -84.57%  (p=0.000 n=9+10)
Marshal/amqp.describedType-8                  119ns ± 5%      65ns ± 5%   -45.63%  (p=0.000 n=10+9)
Marshal/map[interface_{}]interface_{}-8       253ns ± 9%      79ns ± 4%   -68.82%  (p=0.000 n=9+10)
Marshal/map[string]interface_{}-8             252ns ±11%      83ns ± 3%   -67.08%  (p=0.000 n=10+9)
Marshal/amqp.ArrayUByte-8                    38.5ns ± 4%    29.6ns ± 1%   -23.25%  (p=0.000 n=10+9)
Marshal/[]int8-8                             47.2ns ± 5%    24.9ns ± 5%   -47.28%  (p=0.000 n=10+9)
Marshal/[]uint16-8                           75.1ns ± 3%    24.1ns ± 5%   -67.84%  (p=0.000 n=10+10)
Marshal/[]uint16#01-8                        75.4ns ± 4%    24.4ns ± 5%   -67.60%  (p=0.000 n=10+10)
Marshal/[]int16-8                            75.0ns ± 6%    24.6ns ± 4%   -67.26%  (p=0.000 n=10+10)
Marshal/[]int16#01-8                         73.7ns ± 4%    23.9ns ± 7%   -67.64%  (p=0.000 n=10+10)
Marshal/[]uint32-8                            106ns ± 4%      24ns ± 2%   -77.50%  (p=0.000 n=10+9)
Marshal/[]uint32#01-8                        49.6ns ± 5%    26.7ns ± 6%   -46.18%  (p=0.000 n=10+10)
Marshal/[]int32-8                             105ns ± 3%      23ns ± 4%   -77.70%  (p=0.000 n=10+8)
Marshal/[]int32#01-8                         49.0ns ± 3%    27.1ns ± 5%   -44.69%  (p=0.000 n=9+9)
Marshal/[]uint64-8                            172ns ± 4%      24ns ± 3%   -85.81%  (p=0.000 n=10+10)
Marshal/[]uint64#01-8                        49.2ns ± 3%    26.7ns ± 2%   -45.72%  (p=0.000 n=10+8)
Marshal/[]int64-8                             172ns ± 2%      25ns ± 3%   -85.57%  (p=0.000 n=8+9)
Marshal/[]int64#01-8                         49.1ns ± 4%    27.2ns ± 4%   -44.62%  (p=0.000 n=10+10)
Marshal/[]float32-8                          90.6ns ± 3%    23.0ns ± 3%   -74.58%  (p=0.000 n=9+9)
Marshal/[]float64-8                           143ns ± 6%      23ns ± 9%   -83.87%  (p=0.000 n=10+10)
Marshal/[]bool-8                             44.0ns ± 4%    21.8ns ±10%   -50.45%  (p=0.000 n=10+10)
Marshal/[]string-8                            131ns ± 6%      43ns ± 3%   -67.25%  (p=0.000 n=10+10)
Marshal/[]amqp.symbol-8                       130ns ± 3%      41ns ± 2%   -68.39%  (p=0.000 n=10+10)
Marshal/[][]uint8-8                           127ns ± 4%      37ns ± 6%   -71.02%  (p=0.000 n=10+8)
Marshal/[]time.Time-8                        58.9ns ± 4%    19.5ns ± 4%   -66.87%  (p=0.000 n=10+10)
Marshal/[]amqp.UUID-8                        55.0ns ± 2%    20.2ns ± 5%   -63.20%  (p=0.000 n=10+10)
Marshal/[]interface_{}-8                      125ns ± 3%      43ns ± 5%   -65.89%  (p=0.000 n=8+10)
Unmarshal/*amqp.performOpen-8                1.65µs ± 3%    0.91µs ±15%   -44.61%  (p=0.000 n=10+10)
Unmarshal/*amqp.performBegin-8               1.33µs ± 4%    0.78µs ±14%   -41.35%  (p=0.000 n=10+10)
Unmarshal/*amqp.performAttach-8              6.09µs ± 6%    3.80µs ±17%   -37.52%  (p=0.000 n=10+10)
Unmarshal/amqp.role-8                         215ns ±14%      58ns ± 8%   -73.18%  (p=0.000 n=10+10)
Unmarshal/*amqp.unsettled-8                   938ns ±20%     629ns ± 9%   -33.01%  (p=0.000 n=10+9)
Unmarshal/*amqp.source-8                     2.19µs ±11%    1.43µs ±25%   -34.87%  (p=0.000 n=10+10)
Unmarshal/*amqp.target-8                     1.29µs ± 5%    0.78µs ± 9%   -39.50%  (p=0.000 n=10+10)
Unmarshal/*amqp.performFlow-8                1.82µs ± 1%    0.77µs ±15%   -57.89%  (p=0.000 n=10+10)
Unmarshal/*amqp.performTransfer-8            1.71µs ± 2%    0.47µs ± 1%   -72.26%  (p=0.000 n=10+10)
Unmarshal/*amqp.performDisposition-8          910ns ± 1%     242ns ± 1%   -73.37%  (p=0.000 n=10+10)
Unmarshal/*amqp.performDetach-8              1.49µs ± 3%    0.85µs ± 9%   -42.86%  (p=0.000 n=10+9)
Unmarshal/*amqp.performDetach#01-8           1.93µs ± 7%    1.22µs ±13%   -36.82%  (p=0.000 n=10+10)
Unmarshal/amqp.ErrorCondition-8               271ns ±15%      92ns ±14%   -65.93%  (p=0.000 n=10+10)
Unmarshal/*amqp.Error-8                      1.19µs ± 9%    0.76µs ±17%   -36.36%  (p=0.000 n=10+10)
Unmarshal/*amqp.performEnd-8                 1.38µs ± 4%    0.86µs ±23%   -37.86%  (p=0.000 n=10+10)
Unmarshal/*amqp.performClose-8               1.32µs ± 2%    0.82µs ± 8%   -38.12%  (p=0.000 n=8+10)
Unmarshal/*amqp.Message-8                    4.66µs ± 4%    2.94µs ±16%   -36.87%  (p=0.000 n=10+10)
Unmarshal/*amqp.MessageHeader-8               647ns ± 0%     206ns ± 1%   -68.18%  (p=0.000 n=8+9)
Unmarshal/*amqp.MessageProperties-8          1.47µs ± 1%    0.53µs ± 1%   -63.75%  (p=0.000 n=10+10)
Unmarshal/*amqp.stateReceived-8               385ns ± 2%     126ns ± 1%   -67.23%  (p=0.000 n=9+10)
Unmarshal/*amqp.stateAccepted-8               255ns ±17%      94ns ± 3%   -63.08%  (p=0.000 n=10+10)
Unmarshal/*amqp.stateRejected-8              1.40µs ± 4%    0.87µs ±11%   -38.12%  (p=0.000 n=9+10)
Unmarshal/*amqp.stateReleased-8               251ns ± 9%      94ns ± 4%   -62.81%  (p=0.000 n=10+10)
Unmarshal/*amqp.stateModified-8              1.01µs ± 8%    0.68µs ±21%   -33.07%  (p=0.000 n=9+10)
Unmarshal/amqp.lifetimePolicy-8               203ns ± 7%      63ns ± 7%   -68.74%  (p=0.000 n=10+9)
Unmarshal/amqp.SenderSettleMode-8             218ns ± 9%      57ns ±21%   -73.84%  (p=0.000 n=9+10)
Unmarshal/amqp.ReceiverSettleMode-8           221ns ±11%      57ns ± 7%   -74.38%  (p=0.000 n=10+9)
Unmarshal/*amqp.saslInit-8                    551ns ± 1%     220ns ± 1%   -60.10%  (p=0.000 n=10+10)
Unmarshal/*amqp.saslMechanisms-8              420ns ± 2%     187ns ± 1%   -55.35%  (p=0.000 n=10+9)
Unmarshal/*amqp.saslOutcome-8                 511ns ± 2%     187ns ± 2%   -63.46%  (p=0.000 n=10+9)
Unmarshal/amqp.milliseconds-8                 189ns ±22%      60ns ±17%   -68.31%  (p=0.000 n=10+10)
Unmarshal/amqp.symbol-8                       201ns ±12%      74ns ±21%   -63.44%  (p=0.000 n=10+10)
Unmarshal/map[amqp.symbol]interface_{}-8      897ns ±31%     614ns ±16%   -31.57%  (p=0.000 n=10+10)
Unmarshal/amqp.UUID-8                         215ns ±16%      66ns ±12%   -69.16%  (p=0.000 n=10+10)
Unmarshal/bool-8                              174ns ±34%      56ns ±10%   -67.75%  (p=0.000 n=10+10)
Unmarshal/int8-8                              201ns ±26%      54ns ±17%   -72.95%  (p=0.000 n=10+10)
Unmarshal/int8#01-8                           175ns ±23%      57ns ±21%   -67.47%  (p=0.000 n=10+10)
Unmarshal/int16-8                             189ns ±15%      56ns ±16%   -70.29%  (p=0.000 n=10+10)
Unmarshal/int16#01-8                          185ns ±22%      55ns ±17%   -70.31%  (p=0.000 n=10+10)
Unmarshal/int32-8                             198ns ±13%      53ns ±11%   -73.27%  (p=0.000 n=10+9)
Unmarshal/int32#01-8                          200ns ±14%      55ns ±13%   -72.32%  (p=0.000 n=10+10)
Unmarshal/int64-8                             206ns ±16%      56ns ±19%   -72.93%  (p=0.000 n=10+10)
Unmarshal/int64#01-8                          190ns ±14%      52ns ±12%   -72.48%  (p=0.000 n=10+9)
Unmarshal/uint8-8                             188ns ±11%      55ns ±13%   -70.70%  (p=0.000 n=10+10)
Unmarshal/uint16-8                            197ns ±12%      55ns ±11%   -72.16%  (p=0.000 n=10+10)
Unmarshal/uint32-8                            187ns ±14%      57ns ±10%   -69.62%  (p=0.000 n=8+9)
Unmarshal/uint64-8                            174ns ±23%      54ns ±27%   -68.90%  (p=0.000 n=10+10)
Unmarshal/float32-8                           198ns ±24%      55ns ±20%   -72.17%  (p=0.000 n=10+10)
Unmarshal/float32#01-8                        187ns ±15%      55ns ±12%   -70.82%  (p=0.000 n=10+10)
Unmarshal/float32#02-8                        186ns ±19%      56ns ±13%   -69.76%  (p=0.000 n=10+10)
Unmarshal/float32#03-8                        184ns ±12%      52ns ±13%   -71.93%  (p=0.000 n=10+10)
Unmarshal/float64-8                           179ns ± 7%      54ns ± 7%   -69.55%  (p=0.000 n=9+10)
Unmarshal/float64#01-8                        188ns ±17%      54ns ±16%   -71.39%  (p=0.000 n=10+10)
Unmarshal/float64#02-8                        186ns ±15%      55ns ±19%   -70.35%  (p=0.000 n=10+10)
Unmarshal/float64#03-8                        185ns ±13%      56ns ±21%   -69.69%  (p=0.000 n=10+10)
Unmarshal/amqp.describedType-8                413ns ±12%     203ns ±11%   -50.91%  (p=0.000 n=10+10)
Unmarshal/map[interface_{}]interface_{}-8     774ns ±22%     618ns ±17%   -20.15%  (p=0.000 n=10+10)
Unmarshal/map[string]interface_{}-8           769ns ±35%     591ns ±17%   -23.16%  (p=0.015 n=10+10)
Unmarshal/amqp.ArrayUByte-8                   203ns ±16%      88ns ±10%   -56.70%  (p=0.000 n=10+10)
Unmarshal/[]int8-8                            205ns ±12%      58ns ±10%   -71.96%  (p=0.000 n=9+9)
Unmarshal/[]uint16-8                          194ns ±14%      63ns ±18%   -67.66%  (p=0.000 n=10+10)
Unmarshal/[]uint16#01-8                       194ns ±20%      62ns ±12%   -68.16%  (p=0.000 n=10+10)
Unmarshal/[]int16-8                           200ns ±12%      61ns ± 6%   -69.48%  (p=0.000 n=10+9)
Unmarshal/[]int16#01-8                        200ns ± 7%      64ns ±14%   -68.04%  (p=0.000 n=10+10)
Unmarshal/[]uint32-8                          193ns ±16%      61ns ±10%   -68.53%  (p=0.000 n=10+10)
Unmarshal/[]uint32#01-8                       200ns ±20%      58ns ±11%   -70.86%  (p=0.000 n=10+10)
Unmarshal/[]int32-8                           201ns ±20%      64ns ±15%   -68.14%  (p=0.000 n=10+10)
Unmarshal/[]int32#01-8                        187ns ±14%      60ns ±17%   -67.67%  (p=0.000 n=9+10)
Unmarshal/[]uint64-8                          182ns ±12%      63ns ±12%   -65.47%  (p=0.000 n=10+10)
Unmarshal/[]uint64#01-8                       207ns ± 8%      60ns ±16%   -70.82%  (p=0.000 n=9+10)
Unmarshal/[]int64-8                           202ns ±20%      64ns ±10%   -68.57%  (p=0.000 n=10+10)
Unmarshal/[]int64#01-8                        197ns ±19%      56ns ± 9%   -71.50%  (p=0.000 n=10+9)
Unmarshal/[]float32-8                         197ns ±14%      61ns ±16%   -68.78%  (p=0.000 n=10+9)
Unmarshal/[]float64-8                         202ns ±16%      64ns ± 7%   -68.32%  (p=0.000 n=10+9)
Unmarshal/[]bool-8                            195ns ±15%      61ns ± 6%   -68.76%  (p=0.000 n=10+9)
Unmarshal/[]string-8                          249ns ±10%     109ns ± 5%   -56.19%  (p=0.000 n=10+10)
Unmarshal/[]amqp.symbol-8                     253ns ± 9%     110ns ± 5%   -56.60%  (p=0.000 n=10+10)
Unmarshal/[][]uint8-8                         285ns ± 3%     139ns ± 6%   -51.29%  (p=0.000 n=8+10)
Unmarshal/[]time.Time-8                       192ns ±15%      61ns ± 6%   -68.44%  (p=0.000 n=10+10)
Unmarshal/[]amqp.UUID-8                       192ns ±12%      61ns ±12%   -67.98%  (p=0.000 n=10+10)
Unmarshal/[]interface_{}-8                    296ns ± 8%     142ns ± 4%   -51.92%  (p=0.000 n=9+10)

name                                       old alloc/op   new alloc/op   delta
FrameMarshal/transfer-8                       0.00B          0.00B           ~     (all equal)
FrameUnmarshal/transfer-8                      312B ± 0%      232B ± 0%   -25.64%  (p=0.000 n=10+10)
Marshal/*amqp.performOpen-8                    115B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.performBegin-8                   115B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.performAttach-8                  576B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
Marshal/amqp.role-8                           0.00B          0.00B           ~     (all equal)
Marshal/*amqp.unsettled-8                      115B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.source-8                         230B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.target-8                         115B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.performFlow-8                    115B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.performTransfer-8               0.00B          0.00B           ~     (all equal)
Marshal/*amqp.performDisposition-8            0.00B          0.00B           ~     (all equal)
Marshal/*amqp.performDetach-8                  131B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.performDetach#01-8               617B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
Marshal/amqp.ErrorCondition-8                 16.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.Error-8                          131B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.performEnd-8                     131B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.performClose-8                   131B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.Message-8                        464B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.MessageHeader-8                 4.00B ± 0%     0.00B       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.MessageProperties-8             0.00B          0.00B           ~     (all equal)
Marshal/*amqp.stateReceived-8                 0.00B          0.00B           ~     (all equal)
Marshal/*amqp.stateAccepted-8                 0.00B          0.00B           ~     (all equal)
Marshal/*amqp.stateRejected-8                  131B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.stateReleased-8                 0.00B          0.00B           ~     (all equal)
Marshal/*amqp.stateModified-8                  115B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
Marshal/amqp.lifetimePolicy-8                 0.00B          0.00B           ~     (all equal)
Marshal/amqp.SenderSettleMode-8               0.00B          0.00B           ~     (all equal)
Marshal/amqp.ReceiverSettleMode-8             0.00B          0.00B           ~     (all equal)
Marshal/*amqp.saslInit-8                      0.00B          0.00B           ~     (all equal)
Marshal/*amqp.saslMechanisms-8                32.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.saslOutcome-8                   32.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
Marshal/amqp.milliseconds-8                   4.00B ± 0%     0.00B       -100.00%  (p=0.000 n=10+10)
Marshal/amqp.symbol-8                         0.00B          0.00B           ~     (all equal)
Marshal/map[amqp.symbol]interface_{}-8         115B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
Marshal/amqp.UUID-8                           16.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
Marshal/bool-8                                0.00B          0.00B           ~     (all equal)
Marshal/int8-8                                0.00B          0.00B           ~     (all equal)
Marshal/int8#01-8                             0.00B          0.00B           ~     (all equal)
Marshal/int16-8                               0.00B          0.00B           ~     (all equal)
Marshal/int16#01-8                            0.00B          0.00B           ~     (all equal)
Marshal/int32-8                               0.00B          0.00B           ~     (all equal)
Marshal/int32#01-8                            0.00B          0.00B           ~     (all equal)
Marshal/int64-8                               0.00B          0.00B           ~     (all equal)
Marshal/int64#01-8                            0.00B          0.00B           ~     (all equal)
Marshal/uint8-8                               0.00B          0.00B           ~     (all equal)
Marshal/uint16-8                              0.00B          0.00B           ~     (all equal)
Marshal/uint32-8                              0.00B          0.00B           ~     (all equal)
Marshal/uint64-8                              0.00B          0.00B           ~     (all equal)
Marshal/float32-8                             0.00B          0.00B           ~     (all equal)
Marshal/float32#01-8                          0.00B          0.00B           ~     (all equal)
Marshal/float32#02-8                          0.00B          0.00B           ~     (all equal)
Marshal/float32#03-8                          0.00B          0.00B           ~     (all equal)
Marshal/float64-8                             0.00B          0.00B           ~     (all equal)
Marshal/float64#01-8                          0.00B          0.00B           ~     (all equal)
Marshal/float64#02-8                          0.00B          0.00B           ~     (all equal)
Marshal/float64#03-8                          0.00B          0.00B           ~     (all equal)
Marshal/amqp.describedType-8                  0.00B          0.00B           ~     (all equal)
Marshal/map[interface_{}]interface_{}-8        115B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
Marshal/map[string]interface_{}-8              115B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
Marshal/amqp.ArrayUByte-8                     0.00B          0.00B           ~     (all equal)
Marshal/[]int8-8                              0.00B          0.00B           ~     (all equal)
Marshal/[]uint16-8                            0.00B          0.00B           ~     (all equal)
Marshal/[]uint16#01-8                         0.00B          0.00B           ~     (all equal)
Marshal/[]int16-8                             0.00B          0.00B           ~     (all equal)
Marshal/[]int16#01-8                          0.00B          0.00B           ~     (all equal)
Marshal/[]uint32-8                            0.00B          0.00B           ~     (all equal)
Marshal/[]uint32#01-8                         0.00B          0.00B           ~     (all equal)
Marshal/[]int32-8                             0.00B          0.00B           ~     (all equal)
Marshal/[]int32#01-8                          0.00B          0.00B           ~     (all equal)
Marshal/[]uint64-8                            0.00B          0.00B           ~     (all equal)
Marshal/[]uint64#01-8                         0.00B          0.00B           ~     (all equal)
Marshal/[]int64-8                             0.00B          0.00B           ~     (all equal)
Marshal/[]int64#01-8                          0.00B          0.00B           ~     (all equal)
Marshal/[]float32-8                           0.00B          0.00B           ~     (all equal)
Marshal/[]float64-8                           0.00B          0.00B           ~     (all equal)
Marshal/[]bool-8                              0.00B          0.00B           ~     (all equal)
Marshal/[]string-8                            0.00B          0.00B           ~     (all equal)
Marshal/[]amqp.symbol-8                       0.00B          0.00B           ~     (all equal)
Marshal/[][]uint8-8                           0.00B          0.00B           ~     (all equal)
Marshal/[]time.Time-8                         0.00B          0.00B           ~     (all equal)
Marshal/[]amqp.UUID-8                         16.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
Marshal/[]interface_{}-8                      0.00B          0.00B           ~     (all equal)
Unmarshal/*amqp.performOpen-8                  544B ± 0%      464B ± 0%   -14.71%  (p=0.000 n=10+10)
Unmarshal/*amqp.performBegin-8                 496B ± 0%      416B ± 0%   -16.13%  (p=0.000 n=10+10)
Unmarshal/*amqp.performAttach-8              2.08kB ± 0%    2.00kB ± 0%    -3.85%  (p=0.000 n=10+10)
Unmarshal/amqp.role-8                          112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/*amqp.unsettled-8                    480B ± 0%      400B ± 0%   -16.67%  (p=0.000 n=10+10)
Unmarshal/*amqp.source-8                       928B ± 0%      848B ± 0%    -8.62%  (p=0.000 n=10+10)
Unmarshal/*amqp.target-8                       512B ± 0%      432B ± 0%   -15.62%  (p=0.000 n=10+10)
Unmarshal/*amqp.performFlow-8                  464B ± 0%      400B ± 0%   -13.79%  (p=0.000 n=10+10)
Unmarshal/*amqp.performTransfer-8              168B ± 0%       96B ± 0%   -42.86%  (p=0.000 n=10+10)
Unmarshal/*amqp.performDisposition-8           112B ± 0%       36B ± 0%   -67.86%  (p=0.000 n=10+10)
Unmarshal/*amqp.performDetach-8                512B ± 0%      432B ± 0%   -15.62%  (p=0.000 n=10+10)
Unmarshal/*amqp.performDetach#01-8             728B ± 0%      648B ± 0%   -10.99%  (p=0.000 n=10+10)
Unmarshal/amqp.ErrorCondition-8                128B ± 0%       48B ± 0%   -62.50%  (p=0.000 n=10+10)
Unmarshal/*amqp.Error-8                        512B ± 0%      432B ± 0%   -15.62%  (p=0.000 n=10+10)
Unmarshal/*amqp.performEnd-8                   512B ± 0%      432B ± 0%   -15.62%  (p=0.000 n=10+10)
Unmarshal/*amqp.performClose-8                 512B ± 0%      432B ± 0%   -15.62%  (p=0.000 n=10+10)
Unmarshal/*amqp.Message-8                    1.73kB ± 0%    1.65kB ± 0%    -4.63%  (p=0.000 n=10+10)
Unmarshal/*amqp.MessageHeader-8                128B ± 0%       48B ± 0%   -62.50%  (p=0.000 n=10+10)
Unmarshal/*amqp.MessageProperties-8            208B ± 0%      128B ± 0%   -38.46%  (p=0.000 n=10+10)
Unmarshal/*amqp.stateReceived-8                112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/*amqp.stateAccepted-8                112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/*amqp.stateRejected-8                517B ± 0%      437B ± 0%   -15.47%  (p=0.000 n=10+10)
Unmarshal/*amqp.stateReleased-8                112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/*amqp.stateModified-8                480B ± 0%      400B ± 0%   -16.67%  (p=0.000 n=10+10)
Unmarshal/amqp.lifetimePolicy-8                112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/amqp.SenderSettleMode-8              112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/amqp.ReceiverSettleMode-8            112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/*amqp.saslInit-8                     134B ± 0%       54B ± 0%   -59.70%  (p=0.000 n=10+10)
Unmarshal/*amqp.saslMechanisms-8               121B ± 0%       41B ± 0%   -66.12%  (p=0.000 n=10+10)
Unmarshal/*amqp.saslOutcome-8                  144B ± 0%       64B ± 0%   -55.56%  (p=0.000 n=10+10)
Unmarshal/amqp.milliseconds-8                  112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/amqp.symbol-8                        120B ± 0%       40B ± 0%   -66.67%  (p=0.000 n=10+10)
Unmarshal/map[amqp.symbol]interface_{}-8       500B ± 0%      420B ± 0%   -16.00%  (p=0.000 n=10+10)
Unmarshal/amqp.UUID-8                          128B ± 0%       32B ± 0%   -75.00%  (p=0.000 n=10+10)
Unmarshal/bool-8                               112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/int8-8                               112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/int8#01-8                            112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/int16-8                              112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/int16#01-8                           112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/int32-8                              112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/int32#01-8                           112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/int64-8                              112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/int64#01-8                           112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/uint8-8                              112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/uint16-8                             112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/uint32-8                             112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/uint64-8                             112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/float32-8                            112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/float32#01-8                         112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/float32#02-8                         112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/float32#03-8                         112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/float64-8                            112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/float64#01-8                         112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/float64#02-8                         112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/float64#03-8                         112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/amqp.describedType-8                 184B ± 0%      104B ± 0%   -43.48%  (p=0.000 n=10+10)
Unmarshal/map[interface_{}]interface_{}-8      500B ± 0%      420B ± 0%   -16.00%  (p=0.000 n=10+10)
Unmarshal/map[string]interface_{}-8            500B ± 0%      420B ± 0%   -16.00%  (p=0.000 n=10+10)
Unmarshal/amqp.ArrayUByte-8                    112B ± 0%       40B ± 0%   -64.29%  (p=0.000 n=10+10)
Unmarshal/[]int8-8                             112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/[]uint16-8                           112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/[]uint16#01-8                        112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/[]int16-8                            112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/[]int16#01-8                         112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/[]uint32-8                           112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/[]uint32#01-8                        112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/[]int32-8                            112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/[]int32#01-8                         112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/[]uint64-8                           112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/[]uint64#01-8                        112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/[]int64-8                            112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/[]int64#01-8                         112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/[]float32-8                          112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/[]float64-8                          112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/[]bool-8                             112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/[]string-8                           121B ± 0%       41B ± 0%   -66.12%  (p=0.000 n=10+10)
Unmarshal/[]amqp.symbol-8                      121B ± 0%       41B ± 0%   -66.12%  (p=0.000 n=10+10)
Unmarshal/[][]uint8-8                          136B ± 0%       56B ± 0%   -58.82%  (p=0.000 n=10+10)
Unmarshal/[]time.Time-8                        112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/[]amqp.UUID-8                        112B ± 0%       32B ± 0%   -71.43%  (p=0.000 n=10+10)
Unmarshal/[]interface_{}-8                     136B ± 0%       56B ± 0%   -58.82%  (p=0.000 n=10+10)

name                                       old allocs/op  new allocs/op  delta
FrameMarshal/transfer-8                        0.00           0.00           ~     (all equal)
FrameUnmarshal/transfer-8                      8.00 ± 0%      8.00 ± 0%      ~     (all equal)
Marshal/*amqp.performOpen-8                    2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.performBegin-8                   2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.performAttach-8                  10.0 ± 0%       0.0       -100.00%  (p=0.000 n=10+10)
Marshal/amqp.role-8                            0.00           0.00           ~     (all equal)
Marshal/*amqp.unsettled-8                      2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.source-8                         4.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.target-8                         2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.performFlow-8                    2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.performTransfer-8                0.00           0.00           ~     (all equal)
Marshal/*amqp.performDisposition-8             0.00           0.00           ~     (all equal)
Marshal/*amqp.performDetach-8                  3.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.performDetach#01-8               4.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/amqp.ErrorCondition-8                  1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.Error-8                          3.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.performEnd-8                     3.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.performClose-8                   3.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.Message-8                        9.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.MessageHeader-8                  1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.MessageProperties-8              0.00           0.00           ~     (all equal)
Marshal/*amqp.stateReceived-8                  0.00           0.00           ~     (all equal)
Marshal/*amqp.stateAccepted-8                  0.00           0.00           ~     (all equal)
Marshal/*amqp.stateRejected-8                  3.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.stateReleased-8                  0.00           0.00           ~     (all equal)
Marshal/*amqp.stateModified-8                  2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/amqp.lifetimePolicy-8                  0.00           0.00           ~     (all equal)
Marshal/amqp.SenderSettleMode-8                0.00           0.00           ~     (all equal)
Marshal/amqp.ReceiverSettleMode-8              0.00           0.00           ~     (all equal)
Marshal/*amqp.saslInit-8                       0.00           0.00           ~     (all equal)
Marshal/*amqp.saslMechanisms-8                 1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/*amqp.saslOutcome-8                    1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/amqp.milliseconds-8                    1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/amqp.symbol-8                          0.00           0.00           ~     (all equal)
Marshal/map[amqp.symbol]interface_{}-8         2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/amqp.UUID-8                            1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/bool-8                                 0.00           0.00           ~     (all equal)
Marshal/int8-8                                 0.00           0.00           ~     (all equal)
Marshal/int8#01-8                              0.00           0.00           ~     (all equal)
Marshal/int16-8                                0.00           0.00           ~     (all equal)
Marshal/int16#01-8                             0.00           0.00           ~     (all equal)
Marshal/int32-8                                0.00           0.00           ~     (all equal)
Marshal/int32#01-8                             0.00           0.00           ~     (all equal)
Marshal/int64-8                                0.00           0.00           ~     (all equal)
Marshal/int64#01-8                             0.00           0.00           ~     (all equal)
Marshal/uint8-8                                0.00           0.00           ~     (all equal)
Marshal/uint16-8                               0.00           0.00           ~     (all equal)
Marshal/uint32-8                               0.00           0.00           ~     (all equal)
Marshal/uint64-8                               0.00           0.00           ~     (all equal)
Marshal/float32-8                              0.00           0.00           ~     (all equal)
Marshal/float32#01-8                           0.00           0.00           ~     (all equal)
Marshal/float32#02-8                           0.00           0.00           ~     (all equal)
Marshal/float32#03-8                           0.00           0.00           ~     (all equal)
Marshal/float64-8                              0.00           0.00           ~     (all equal)
Marshal/float64#01-8                           0.00           0.00           ~     (all equal)
Marshal/float64#02-8                           0.00           0.00           ~     (all equal)
Marshal/float64#03-8                           0.00           0.00           ~     (all equal)
Marshal/amqp.describedType-8                   0.00           0.00           ~     (all equal)
Marshal/map[interface_{}]interface_{}-8        2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/map[string]interface_{}-8              2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/amqp.ArrayUByte-8                      0.00           0.00           ~     (all equal)
Marshal/[]int8-8                               0.00           0.00           ~     (all equal)
Marshal/[]uint16-8                             0.00           0.00           ~     (all equal)
Marshal/[]uint16#01-8                          0.00           0.00           ~     (all equal)
Marshal/[]int16-8                              0.00           0.00           ~     (all equal)
Marshal/[]int16#01-8                           0.00           0.00           ~     (all equal)
Marshal/[]uint32-8                             0.00           0.00           ~     (all equal)
Marshal/[]uint32#01-8                          0.00           0.00           ~     (all equal)
Marshal/[]int32-8                              0.00           0.00           ~     (all equal)
Marshal/[]int32#01-8                           0.00           0.00           ~     (all equal)
Marshal/[]uint64-8                             0.00           0.00           ~     (all equal)
Marshal/[]uint64#01-8                          0.00           0.00           ~     (all equal)
Marshal/[]int64-8                              0.00           0.00           ~     (all equal)
Marshal/[]int64#01-8                           0.00           0.00           ~     (all equal)
Marshal/[]float32-8                            0.00           0.00           ~     (all equal)
Marshal/[]float64-8                            0.00           0.00           ~     (all equal)
Marshal/[]bool-8                               0.00           0.00           ~     (all equal)
Marshal/[]string-8                             0.00           0.00           ~     (all equal)
Marshal/[]amqp.symbol-8                        0.00           0.00           ~     (all equal)
Marshal/[][]uint8-8                            0.00           0.00           ~     (all equal)
Marshal/[]time.Time-8                          0.00           0.00           ~     (all equal)
Marshal/[]amqp.UUID-8                          1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Marshal/[]interface_{}-8                       0.00           0.00           ~     (all equal)
Unmarshal/*amqp.performOpen-8                  13.0 ± 0%      13.0 ± 0%      ~     (all equal)
Unmarshal/*amqp.performBegin-8                 8.00 ± 0%      8.00 ± 0%      ~     (all equal)
Unmarshal/*amqp.performAttach-8                33.0 ± 0%      33.0 ± 0%      ~     (all equal)
Unmarshal/amqp.role-8                          1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/*amqp.unsettled-8                    5.00 ± 0%      5.00 ± 0%      ~     (all equal)
Unmarshal/*amqp.source-8                       15.0 ± 0%      15.0 ± 0%      ~     (all equal)
Unmarshal/*amqp.target-8                       8.00 ± 0%      8.00 ± 0%      ~     (all equal)
Unmarshal/*amqp.performFlow-8                  5.00 ± 0%     10.00 ± 0%  +100.00%  (p=0.000 n=10+10)
Unmarshal/*amqp.performTransfer-8              4.00 ± 0%      6.00 ± 0%   +50.00%  (p=0.000 n=10+10)
Unmarshal/*amqp.performDisposition-8           1.00 ± 0%      2.00 ± 0%  +100.00%  (p=0.000 n=10+10)
Unmarshal/*amqp.performDetach-8                10.0 ± 0%      10.0 ± 0%      ~     (all equal)
Unmarshal/*amqp.performDetach#01-8             15.0 ± 0%      15.0 ± 0%      ~     (all equal)
Unmarshal/amqp.ErrorCondition-8                2.00 ± 0%      2.00 ± 0%      ~     (all equal)
Unmarshal/*amqp.Error-8                        10.0 ± 0%      10.0 ± 0%      ~     (all equal)
Unmarshal/*amqp.performEnd-8                   10.0 ± 0%      10.0 ± 0%      ~     (all equal)
Unmarshal/*amqp.performClose-8                 10.0 ± 0%      10.0 ± 0%      ~     (all equal)
Unmarshal/*amqp.Message-8                      33.0 ± 0%      33.0 ± 0%      ~     (all equal)
Unmarshal/*amqp.MessageHeader-8                2.00 ± 0%      2.00 ± 0%      ~     (all equal)
Unmarshal/*amqp.MessageProperties-8            12.0 ± 0%      12.0 ± 0%      ~     (all equal)
Unmarshal/*amqp.stateReceived-8                1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/*amqp.stateAccepted-8                1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/*amqp.stateRejected-8                10.0 ± 0%      10.0 ± 0%      ~     (all equal)
Unmarshal/*amqp.stateReleased-8                1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/*amqp.stateModified-8                6.00 ± 0%      6.00 ± 0%      ~     (all equal)
Unmarshal/amqp.lifetimePolicy-8                1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/amqp.SenderSettleMode-8              1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/amqp.ReceiverSettleMode-8            1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/*amqp.saslInit-8                     4.00 ± 0%      4.00 ± 0%      ~     (all equal)
Unmarshal/*amqp.saslMechanisms-8               4.00 ± 0%      4.00 ± 0%      ~     (all equal)
Unmarshal/*amqp.saslOutcome-8                  2.00 ± 0%      2.00 ± 0%      ~     (all equal)
Unmarshal/amqp.milliseconds-8                  1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/amqp.symbol-8                        2.00 ± 0%      2.00 ± 0%      ~     (all equal)
Unmarshal/map[amqp.symbol]interface_{}-8       6.00 ± 0%      6.00 ± 0%      ~     (all equal)
Unmarshal/amqp.UUID-8                          2.00 ± 0%      1.00 ± 0%   -50.00%  (p=0.000 n=10+10)
Unmarshal/bool-8                               1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/int8-8                               1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/int8#01-8                            1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/int16-8                              1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/int16#01-8                           1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/int32-8                              1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/int32#01-8                           1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/int64-8                              1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/int64#01-8                           1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/uint8-8                              1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/uint16-8                             1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/uint32-8                             1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/uint64-8                             1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/float32-8                            1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/float32#01-8                         1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/float32#02-8                         1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/float32#03-8                         1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/float64-8                            1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/float64#01-8                         1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/float64#02-8                         1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/float64#03-8                         1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/amqp.describedType-8                 4.00 ± 0%      4.00 ± 0%      ~     (all equal)
Unmarshal/map[interface_{}]interface_{}-8      6.00 ± 0%      6.00 ± 0%      ~     (all equal)
Unmarshal/map[string]interface_{}-8            6.00 ± 0%      6.00 ± 0%      ~     (all equal)
Unmarshal/amqp.ArrayUByte-8                    1.00 ± 0%      2.00 ± 0%  +100.00%  (p=0.000 n=10+10)
Unmarshal/[]int8-8                             1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/[]uint16-8                           1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/[]uint16#01-8                        1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/[]int16-8                            1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/[]int16#01-8                         1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/[]uint32-8                           1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/[]uint32#01-8                        1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/[]int32-8                            1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/[]int32#01-8                         1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/[]uint64-8                           1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/[]uint64#01-8                        1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/[]int64-8                            1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/[]int64#01-8                         1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/[]float32-8                          1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/[]float64-8                          1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/[]bool-8                             1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/[]string-8                           4.00 ± 0%      4.00 ± 0%      ~     (all equal)
Unmarshal/[]amqp.symbol-8                      4.00 ± 0%      4.00 ± 0%      ~     (all equal)
Unmarshal/[][]uint8-8                          4.00 ± 0%      4.00 ± 0%      ~     (all equal)
Unmarshal/[]time.Time-8                        1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/[]amqp.UUID-8                        1.00 ± 0%      1.00 ± 0%      ~     (all equal)
Unmarshal/[]interface_{}-8                     4.00 ± 0%      4.00 ± 0%      ~     (all equal)
```