### PR TITLE
Resolve Some TODOs

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -101,10 +101,7 @@ func (b *buffer) readFromOnce(r io.Reader) error {
 
 	n, err := r.Read(b.b[l:cap(b.b)])
 	b.b = b.b[:l+n]
-	if err != nil && err != io.EOF {
-		return err
-	}
-	return nil
+	return err
 }
 
 func (b *buffer) write(p []byte) {


### PR DESCRIPTION
TODOs Resolved:
* Remove `link()` from frameBody interface.
* Properly end a session on `Session.Close()`.

Fixes for bugs found while testing:
* `buffer.readFromOnce` should not ignore `io.EOF`.
* `conn.mux` should always lookup session by `Begin.RemoteChannel` when a Begin performative is received.
