### PR TITLE
Resolve more TODOs

### DIFF
--- a/client.go
+++ b/client.go
@@ -1167,9 +1167,9 @@ func LinkSelectorFilter(filter string) LinkOption {
 			l.source = new(source)
 		}
 		if l.source.Filter == nil {
-			l.source.Filter = make(map[symbol]interface{})
+			l.source.Filter = make(map[symbol]*describedType)
 		}
-		l.source.Filter[name] = describedType{
+		l.source.Filter[name] = &describedType{
 			descriptor: code,
 			value:      filter,
 		}

--- a/conn.go
+++ b/conn.go
@@ -842,6 +842,6 @@ func (c *conn) readFrame() (frame, error) {
 	case p := <-c.rxProto:
 		return fr, errorErrorf("unexpected protocol header %#v", p)
 	case <-deadline:
-		return fr, ErrTimeout // TODO: move to connReader
+		return fr, ErrTimeout
 	}
 }

--- a/encode.go
+++ b/encode.go
@@ -491,6 +491,33 @@ func writeMap(wr *buffer, m interface{}) error {
 				return err
 			}
 		}
+	case Annotations:
+		pairs = len(m) * 2
+		for key, val := range m {
+			switch key := key.(type) {
+			case string:
+				err := symbol(key).marshal(wr)
+				if err != nil {
+					return err
+				}
+			case symbol:
+				err := key.marshal(wr)
+				if err != nil {
+					return err
+				}
+			case int64:
+				writeInt64(wr, key)
+			case int:
+				writeInt64(wr, int64(key))
+			default:
+				return errorErrorf("unsupported Annotations key type %T", key)
+			}
+
+			err := marshal(wr, val)
+			if err != nil {
+				return err
+			}
+		}
 	default:
 		return errorErrorf("unsupported map type %T", m)
 	}

--- a/encode.go
+++ b/encode.go
@@ -479,6 +479,18 @@ func writeMap(wr *buffer, m interface{}) error {
 				return err
 			}
 		}
+	case filter:
+		pairs = len(m) * 2
+		for key, val := range m {
+			err := key.marshal(wr)
+			if err != nil {
+				return err
+			}
+			err = val.marshal(wr)
+			if err != nil {
+				return err
+			}
+		}
 	default:
 		return errorErrorf("unsupported map type %T", m)
 	}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -447,11 +447,11 @@ var (
 				FirstAcquirer: true,
 				DeliveryCount: 32,
 			},
-			DeliveryAnnotations: map[interface{}]interface{}{
-				int8(42): "answer",
+			DeliveryAnnotations: Annotations{
+				int64(42): "answer",
 			},
-			Annotations: map[interface{}]interface{}{
-				int8(42): "answer",
+			Annotations: Annotations{
+				int64(42): "answer",
 			},
 			Properties: &MessageProperties{
 				MessageID:          "yo",
@@ -473,7 +473,7 @@ var (
 			},
 			Data:  []byte("A nice little data payload."),
 			Value: uint8(42),
-			Footer: map[interface{}]interface{}{
+			Footer: Annotations{
 				"hash": []uint8{0, 1, 2, 34, 5, 6, 7, 8, 9, 0},
 			},
 		},

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -280,8 +280,11 @@ var (
 					"lifetime-policy": deleteOnClose,
 				},
 				DistributionMode: "some-mode",
-				Filter: map[symbol]interface{}{
-					"foo:filter": "bar value",
+				Filter: filter{
+					"foo:filter": &describedType{
+						descriptor: "foo:filter",
+						value:      "bar value",
+					},
 				},
 				Outcomes:     []symbol{"amqp:accepted:list"},
 				Capabilities: []symbol{"barCap"},
@@ -323,8 +326,11 @@ var (
 				"lifetime-policy": deleteOnClose,
 			},
 			DistributionMode: "some-mode",
-			Filter: map[symbol]interface{}{
-				"foo:filter": "bar value",
+			Filter: filter{
+				"foo:filter": &describedType{
+					descriptor: "foo:filter",
+					value:      "bar value",
+				},
 			},
 			Outcomes:     []symbol{"amqp:accepted:list"},
 			Capabilities: []symbol{"barCap"},

--- a/types.go
+++ b/types.go
@@ -1531,11 +1531,8 @@ const (
 
 // Error is an AMQP error.
 type Error struct {
-	// TODO: should this implement the error interface?
-
 	// A symbolic value indicating the error condition.
 	Condition ErrorCondition
-	// TODO: make enum
 
 	// descriptive text about the error condition
 	//
@@ -1545,7 +1542,6 @@ type Error struct {
 
 	// map carrying information about the error condition
 	Info map[string]interface{}
-	// TODO: make more user friendly
 }
 
 func (e *Error) marshal(wr *buffer) error {

--- a/types.go
+++ b/types.go
@@ -2010,21 +2010,84 @@ func (h *MessageHeader) unmarshal(r *buffer) error {
 
 // MessageProperties is the defined set of properties for AMQP messages.
 type MessageProperties struct {
-	// TODO: add useful descriptions from spec
+	// Message-id, if set, uniquely identifies a message within the message system.
+	// The message producer is usually responsible for setting the message-id in
+	// such a way that it is assured to be globally unique. A broker MAY discard a
+	// message as a duplicate if the value of the message-id matches that of a
+	// previously received message sent to the same node.
+	MessageID interface{} // uint64, UUID, []byte, or string
 
-	MessageID          interface{} // uint64, UUID, []byte, or string
-	UserID             []byte
-	To                 string
-	Subject            string
-	ReplyTo            string
-	CorrelationID      interface{} // uint64, UUID, []byte, or string
-	ContentType        string
-	ContentEncoding    string
+	// The identity of the user responsible for producing the message.
+	// The client sets this value, and it MAY be authenticated by intermediaries.
+	UserID []byte
+
+	// The to field identifies the node that is the intended destination of the message.
+	// On any given transfer this might not be the node at the receiving end of the link.
+	To string
+
+	// A common field for summary information about the message content and purpose.
+	Subject string
+
+	// The address of the node to send replies to.
+	ReplyTo string
+
+	// This is a client-specific id that can be used to mark or identify messages
+	// between clients.
+	CorrelationID interface{} // uint64, UUID, []byte, or string
+
+	// The RFC-2046 [RFC2046] MIME type for the message's application-data section
+	// (body). As per RFC-2046 [RFC2046] this can contain a charset parameter defining
+	// the character encoding used: e.g., 'text/plain; charset="utf-8"'.
+	//
+	// For clarity, as per section 7.2.1 of RFC-2616 [RFC2616], where the content type
+	// is unknown the content-type SHOULD NOT be set. This allows the recipient the
+	// opportunity to determine the actual type. Where the section is known to be truly
+	// opaque binary data, the content-type SHOULD be set to application/octet-stream.
+	//
+	// When using an application-data section with a section code other than data,
+	// content-type SHOULD NOT be set.
+	ContentType string
+
+	// The content-encoding property is used as a modifier to the content-type.
+	// When present, its value indicates what additional content encodings have been
+	// applied to the application-data, and thus what decoding mechanisms need to be
+	// applied in order to obtain the media-type referenced by the content-type header
+	// field.
+	//
+	// Content-encoding is primarily used to allow a document to be compressed without
+	// losing the identity of its underlying content type.
+	//
+	// Content-encodings are to be interpreted as per section 3.5 of RFC 2616 [RFC2616].
+	// Valid content-encodings are registered at IANA [IANAHTTPPARAMS].
+	//
+	// The content-encoding MUST NOT be set when the application-data section is other
+	// than data. The binary representation of all other application-data section types
+	// is defined completely in terms of the AMQP type system.
+	//
+	// Implementations MUST NOT use the identity encoding. Instead, implementations
+	// SHOULD NOT set this property. Implementations SHOULD NOT use the compress encoding,
+	// except as to remain compatible with messages originally sent with other protocols,
+	// e.g. HTTP or SMTP.
+	//
+	// Implementations SHOULD NOT specify multiple content-encoding values except as to
+	// be compatible with messages originally sent with other protocols, e.g. HTTP or SMTP.
+	ContentEncoding string
+
+	// An absolute time when this message is considered to be expired.
 	AbsoluteExpiryTime time.Time
-	CreationTime       time.Time
-	GroupID            string
-	GroupSequence      uint32 // RFC-1982 sequence number
-	ReplyToGroupID     string
+
+	// An absolute time when this message was created.
+	CreationTime time.Time
+
+	// Identifies the group the message belongs to.
+	GroupID string
+
+	// The relative position of this message within its group.
+	GroupSequence uint32 // RFC-1982 sequence number
+
+	// This is a client-specific id that is used so that client can send replies to this
+	// message to a specific group.
+	ReplyToGroupID string
 }
 
 func (p *MessageProperties) marshal(wr *buffer) error {


### PR DESCRIPTION
* Restrict `source.Filter` map values to `*describedType`.
* Restrict Annotations to string/symbol or int/int64 keys.
* Add descriptions to MessageProperties.
* Minimize encoded size of arrays of variable length types.
* Remove TODOs which are obsolete or otherwise not intended to be done.
* Make TLS connection setup somewhat less convoluted.
* Minimize DeliveryTag to be 8 bytes and fix some transfer frame tracking issues.