### PR TITLE
Support multiple data sections.

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -40,9 +40,7 @@ func Example() {
 		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 
 		// Send message
-		err = sender.Send(ctx, &amqp.Message{
-			Data: []byte("Hello!"),
-		})
+		err = sender.Send(ctx, amqp.NewMessage([]byte("Hello!")))
 		if err != nil {
 			log.Fatal("Sending message:", err)
 		}
@@ -75,7 +73,7 @@ func Example() {
 			// Accept message
 			msg.Accept()
 
-			fmt.Printf("Message received: %s\n", msg.Data)
+			fmt.Printf("Message received: %s\n", msg.GetData())
 		}
 	}
 }

--- a/fuzz.go
+++ b/fuzz.go
@@ -61,9 +61,7 @@ func FuzzConn(data []byte) int {
 		return 0
 	}
 
-	err = sender.Send(context.Background(), &Message{
-		Data: []byte(data),
-	})
+	err = sender.Send(context.Background(), NewMessage(data))
 	if err != nil {
 		return 0
 	}

--- a/integration_test.go
+++ b/integration_test.go
@@ -122,9 +122,7 @@ func TestIntegrationRoundTrip(t *testing.T) {
 
 					for i, data := range tt.data {
 						ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-						err = sender.Send(ctx, &amqp.Message{
-							Data: []byte(data),
-						})
+						err = sender.Send(ctx, amqp.NewMessage([]byte(data)))
 						cancel()
 						if err != nil {
 							sendErr = fmt.Errorf("Error after %d sends: %+v", i, err)
@@ -161,8 +159,8 @@ func TestIntegrationRoundTrip(t *testing.T) {
 						// Accept message
 						msg.Accept()
 
-						if !bytes.Equal([]byte(data), msg.Data) {
-							receiveErr = fmt.Errorf("Expected received message %d to be %v, but it was %v", i+1, string(data), string(msg.Data))
+						if !bytes.Equal([]byte(data), msg.GetData()) {
+							receiveErr = fmt.Errorf("Expected received message %d to be %v, but it was %v", i+1, string(data), string(msg.GetData()))
 						}
 					}
 				}()
@@ -240,9 +238,7 @@ func TestIntegrationSend(t *testing.T) {
 
 			for i, data := range tt.data {
 				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-				err = sender.Send(ctx, &amqp.Message{
-					Data: []byte(data),
-				})
+				err = sender.Send(ctx, amqp.NewMessage([]byte(data)))
 				cancel()
 				if err != nil {
 					t.Fatalf("Error after %d sends: %+v", i, err)

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -471,7 +471,10 @@ var (
 			ApplicationProperties: map[string]interface{}{
 				"baz": "foo",
 			},
-			Data:  []byte("A nice little data payload."),
+			Data: [][]byte{
+				[]byte("A nice little data payload."),
+				[]byte("More payload."),
+			},
 			Value: uint8(42),
 			Footer: Annotations{
 				"hash": []uint8{0, 1, 2, 34, 5, 6, 7, 8, 9, 0},


### PR DESCRIPTION
* `Message.Data` changed to `[][]byte`.
* Added `NewMessage(data []byte)` and `Message.Data() []byte` helpers
  for setting/retrieving single data section messages.