### PR TITLE
add link properties

### DIFF
--- a/client.go
+++ b/client.go
@@ -673,6 +673,7 @@ type link struct {
 	receiver     *Receiver // allows link options to modify Receiver
 	source       *source
 	target       *target
+	properties   map[symbol]interface{} // additional properties sent upon link attach
 
 	// "The delivery-count is initialized by the sender when a link endpoint is created,
 	// and is incremented whenever a message is sent. Only the sender MAY independently
@@ -730,6 +731,7 @@ func attachLink(s *Session, r *Receiver, opts []LinkOption) (*link, error) {
 		MaxMessageSize:     l.maxMessageSize,
 		Source:             l.source,
 		Target:             l.target,
+		Properties:         l.properties,
 	}
 
 	if isReceiver {
@@ -1108,6 +1110,22 @@ func LinkAddress(source string) LinkOption {
 			return LinkSourceAddress(source)(l)
 		}
 		return LinkTargetAddress(source)(l)
+	}
+}
+
+// LinkProperty sets an entry in the link properties map sent to the server.
+//
+// This option can be used multiple times.
+func LinkProperty(key, value string) LinkOption {
+	return func(l *link) error {
+		if key == "" {
+			return errorNew("link property key must not be empty")
+		}
+		if l.properties == nil {
+			l.properties = make(map[symbol]interface{})
+		}
+		l.properties[symbol(key)] = value
+		return nil
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -10,7 +10,8 @@ func TestLinkOptions(t *testing.T) {
 		label string
 		opts  []LinkOption
 
-		wantSource *source
+		wantSource     *source
+		wantProperties map[symbol]interface{}
 	}{
 		{
 			label: "no options",
@@ -19,6 +20,9 @@ func TestLinkOptions(t *testing.T) {
 			label: "selector-filter",
 			opts: []LinkOption{
 				LinkSelectorFilter("amqp.annotation.x-opt-offset > '100'"),
+				LinkProperty("x-opt-test1", "test1"),
+				LinkProperty("x-opt-test2", "test2"),
+				LinkProperty("x-opt-test1", "test3"),
 			},
 
 			wantSource: &source{
@@ -28,6 +32,10 @@ func TestLinkOptions(t *testing.T) {
 						value:      "amqp.annotation.x-opt-offset > '100'",
 					},
 				},
+			},
+			wantProperties: map[symbol]interface{}{
+				"x-opt-test1": "test3",
+				"x-opt-test2": "test2",
 			},
 		},
 	}
@@ -40,7 +48,11 @@ func TestLinkOptions(t *testing.T) {
 			}
 
 			if !testEqual(got.source, tt.wantSource) {
-				t.Errorf("Properties don't match expected:\n %s", testDiff(got.source, tt.wantSource))
+				t.Errorf("Source properties don't match expected:\n %s", testDiff(got.source, tt.wantSource))
+			}
+
+			if !testEqual(got.properties, tt.wantProperties) {
+				t.Errorf("Link properties don't match expected:\n %s", testDiff(got.properties, tt.wantProperties))
 			}
 		})
 	}


### PR DESCRIPTION
- add link properties for use on the attach performative
- add test for expected behavior

#### Example use for link properties:
Event Hub uses link attach performative properties for epoch receivers. An epoch receiver sends an epoch (uint64) as `symbol(com.microsoft:epoch): <value>` to ensure a single receiver is attached to a given partition at any time. [This post explains the outward behavior of the feature.](https://blogs.msdn.microsoft.com/gyan/2014/09/02/event-hubs-receiver-epoch/)