### PR TITLE
Propagate up message rejection errors to Sender.

### DIFF
--- a/types.go
+++ b/types.go
@@ -159,7 +159,7 @@ type frame struct {
 	body    frameBody // body of the frame
 
 	// optional channel which will be closed after net transmit
-	done chan struct{}
+	done chan deliveryState
 }
 
 // frameBody adds some type safety to frame encoding
@@ -1262,7 +1262,7 @@ type performTransfer struct {
 	Payload []byte
 
 	// optional channel to indicate to sender that transfer has completed
-	done chan struct{}
+	done chan deliveryState
 	// complete when receiver has responded with disposition (ReceiverSettleMode = second)
 	// instead of when this message has been sent on network
 	confirmSettlement bool
@@ -1569,6 +1569,10 @@ func (e *Error) String() string {
 		e.Description,
 		e.Info,
 	)
+}
+
+func (e *Error) Error() string {
+	return e.String()
 }
 
 /*


### PR DESCRIPTION
* If the link is receiver-settle-mode second, the original sender
  will receive the error and the link continues to function.
* If the link is not receiver-settle-mode second, it is considered
  a link level error and a future sender will received the message,
  assume the sender continues to read. This isn't ideal, but if
  the sender needs receiver confirmation, they should be using
  receiver-settle-mode second.

Resolves #48