### PR TITLE
Add options to configure window size and properly send session flow updates

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -27,7 +27,7 @@ var (
 	ErrConnClosed = errors.New("amqp: connection closed")
 )
 
-// ConnOption is an function for configuring an AMQP connection.
+// ConnOption is a function for configuring an AMQP connection.
 type ConnOption func(*conn) error
 
 // ConnServerHostname sets the hostname sent in the AMQP


### PR DESCRIPTION
* `Client.NewSession` now takes `...SessionOption`.
* Added `SessionIncomingWindow(uint32)` and `SessionOutgoingWindow(uint32)`.
* Changed default incoming and outgoing windows to 100. This aligns with the Node.js and C# libraries.
* Realized session only sends flow updates when a link does, which can cause a timeout if the message requires more transfers than the incoming-window allows. Corrected to send a flow when remote incoming windows is less than half the configured incoming window.

Resolves #64