### PR TITLE
Rewrite randBytes

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -757,7 +757,7 @@ func (c *conn) openAMQP() stateFunc {
 	c.err = c.writeFrame(frame{
 		type_: frameTypeAMQP,
 		body: &performOpen{
-			ContainerID:  string(randBytes(40)),
+			ContainerID:  randString(40),
 			Hostname:     c.hostname,
 			MaxFrameSize: c.maxFrameSize,
 			ChannelMax:   c.channelMax,


### PR DESCRIPTION
* Create a new rand source to avoid using global rand.
* Use rand.Read and base64 encode the results for simplicity.
* Change to return string since all current consumers convert to string.

Resolves #65 