### PR TITLE
Fix compile error on 386 and run unit tests with GOARCH=386 in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,12 @@ test:
 	go test -tags gofuzz -v -race ./...
 
 integration:
-	go test -tags "integration pkgerrors" -count=1 -v -race ./...
+	go test -tags "integration pkgerrors" -count=1 -v -race .
+
+test386:
+	TEST_CORPUS=1 go test -tags "gofuzz" -count=1 -v .
+
+ci: test386 coverage
 
 coverage:
 	TEST_CORPUS=1 go test -tags "integration gofuzz" -cover -coverprofile=cover.out -v

--- a/client.go
+++ b/client.go
@@ -194,7 +194,7 @@ func SessionMaxLinks(n int) SessionOption {
 		if n < 1 {
 			return errorNew("max sessions cannot be less than 1")
 		}
-		if n > 4294967296 {
+		if int64(n) > 4294967296 {
 			return errorNew("max sessions cannot be greater than 4294967296")
 		}
 		s.handleMax = uint32(n - 1)


### PR DESCRIPTION
Fixes #106 