### PR TITLE
Fix null type handling in readAny

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -579,13 +579,13 @@ func readBinary(r *buffer) ([]byte, error) {
 }
 
 func readAny(r *buffer) (interface{}, error) {
+	if tryReadNull(r) {
+		return nil, nil
+	}
+
 	type_, err := r.peekType()
 	if err != nil {
 		return nil, errorNew("invalid length")
-	}
-
-	if tryReadNull(r) {
-		return nil, nil
 	}
 
 	switch type_ {

--- a/decode.go
+++ b/decode.go
@@ -511,7 +511,7 @@ func readArrayHeader(r *buffer) (length int64, _ error) {
 		}
 		length = int64(binary.BigEndian.Uint32(buf[4:8]))
 	default:
-		return 0, errorErrorf("type code %#02x is not a recognized list type", type_)
+		return 0, errorErrorf("type code %#02x is not a recognized array type", type_)
 	}
 	return length, nil
 }
@@ -568,7 +568,7 @@ func readBinary(r *buffer) ([]byte, error) {
 		}
 		length = int64(binary.BigEndian.Uint32(buf))
 	default:
-		return nil, errorErrorf("type code %#02x is not a recognized string type", type_)
+		return nil, errorErrorf("type code %#02x is not a recognized binary type", type_)
 	}
 
 	buf, ok := r.next(length)
@@ -582,6 +582,10 @@ func readAny(r *buffer) (interface{}, error) {
 	type_, err := r.peekType()
 	if err != nil {
 		return nil, errorNew("invalid length")
+	}
+
+	if tryReadNull(r) {
+		return nil, nil
 	}
 
 	switch type_ {

--- a/encode.go
+++ b/encode.go
@@ -43,7 +43,7 @@ type marshaler interface {
 func marshal(wr *buffer, i interface{}) error {
 	switch t := i.(type) {
 	case nil:
-		writeNull(wr)
+		wr.writeByte(byte(typeCodeNull))
 	case bool:
 		if t {
 			wr.writeByte(byte(typeCodeBoolTrue))
@@ -218,11 +218,6 @@ func marshal(wr *buffer, i interface{}) error {
 		return errorErrorf("marshal not implemented for %T", i)
 	}
 	return nil
-}
-
-func writeNull(wr *buffer) {
-	wr.writeByte(byte(typeCodeNull))
-	return
 }
 
 func writeInt32(wr *buffer, n int32) {

--- a/encode.go
+++ b/encode.go
@@ -42,6 +42,8 @@ type marshaler interface {
 
 func marshal(wr *buffer, i interface{}) error {
 	switch t := i.(type) {
+	case nil:
+		writeNull(wr)
 	case bool:
 		if t {
 			wr.writeByte(byte(typeCodeBoolTrue))
@@ -216,6 +218,11 @@ func marshal(wr *buffer, i interface{}) error {
 		return errorErrorf("marshal not implemented for %T", i)
 	}
 	return nil
+}
+
+func writeNull(wr *buffer) {
+	wr.writeByte(byte(typeCodeNull))
+	return
 }
 
 func writeInt32(wr *buffer, n int32) {

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -188,16 +188,23 @@ func TestMarshalUnmarshal(t *testing.T) {
 				}
 			}
 
-			newType := reflect.New(reflect.TypeOf(type_))
-			err = unmarshal(&buf, newType.Interface())
-			if err != nil {
-				t.Fatal(fmt.Sprintf("%+v", err))
-				return
-			}
-
-			cmpType := reflect.Indirect(newType).Interface()
-			if !testEqual(type_, cmpType) {
-				t.Errorf("Roundtrip produced different results:\n %s", testDiff(type_, cmpType))
+			if type_ == nil {
+				err = unmarshal(&buf, nil)
+				if err != nil {
+					t.Fatal(fmt.Sprintf("%+v", err))
+					return
+				}
+			} else {
+				newType := reflect.New(reflect.TypeOf(type_))
+				err = unmarshal(&buf, newType.Interface())
+				if err != nil {
+					t.Fatal(fmt.Sprintf("%+v", err))
+					return
+				}
+				cmpType := reflect.Indirect(newType).Interface()
+				if !testEqual(type_, cmpType) {
+					t.Errorf("Roundtrip produced different results:\n %s", testDiff(type_, cmpType))
+				}
 			}
 		})
 	}
@@ -537,6 +544,7 @@ var (
 	}
 
 	generalTypes = []interface{}{
+		nil,
 		UUID{1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 14, 15, 16},
 		bool(true),
 		int8(math.MaxInt8),

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -188,23 +188,25 @@ func TestMarshalUnmarshal(t *testing.T) {
 				}
 			}
 
+			// handle special case around nil type
 			if type_ == nil {
 				err = unmarshal(&buf, nil)
 				if err != nil {
 					t.Fatal(fmt.Sprintf("%+v", err))
 					return
 				}
-			} else {
-				newType := reflect.New(reflect.TypeOf(type_))
-				err = unmarshal(&buf, newType.Interface())
-				if err != nil {
-					t.Fatal(fmt.Sprintf("%+v", err))
-					return
-				}
-				cmpType := reflect.Indirect(newType).Interface()
-				if !testEqual(type_, cmpType) {
-					t.Errorf("Roundtrip produced different results:\n %s", testDiff(type_, cmpType))
-				}
+				return
+			}
+
+			newType := reflect.New(reflect.TypeOf(type_))
+			err = unmarshal(&buf, newType.Interface())
+			if err != nil {
+				t.Fatal(fmt.Sprintf("%+v", err))
+				return
+			}
+			cmpType := reflect.Indirect(newType).Interface()
+			if !testEqual(type_, cmpType) {
+				t.Errorf("Roundtrip produced different results:\n %s", testDiff(type_, cmpType))
 			}
 		})
 	}


### PR DESCRIPTION
Currently when unmarshaling a response from a SB lock renewal request the library returns the following error:

> unknown type 0x40 

This is the message it is attempting to read:

```
 response message:
 &{
Format:0 
Header:<nil> 
DeliveryAnnotations:map[] 
Annotations:map[] 
Properties:0xc4203e2380 
ApplicationProperties:
  map[
   statusDescription:<nil>
   com.microsoft:tracking-id:<nil>
   statusCode:200
   errorCondition:<nil>
  ] 
Data:[] 
Value:map[expirations:[2018-07-31 13:30:09.722 +0000 UTC]] 
Footer:map[] 
receiver:0xc42043a1e0 
id:1 
settled:false}
```

When the `readAny` is called the amqp type is `0x40`. ~~I'm unclear on how this occurs as `tryReadNull` is checked in `decode.go/unmarshal`. I think this is related to the nested recursion and its use in `types.go`~~ This occurs when `unmarshal` is called on `mapStringAny` in which the any is a null, stack track below:

![nilreadany](https://user-images.githubusercontent.com/1939288/43465748-e3bd579e-94d5-11e8-823c-ca5597d76bcc.png)

Adding a nil check to the `readAny` function resolved the issue and responses are now correctly received. 

ref: https://github.com/lawrencegripper/ion/issues/157