### PR TITLE
Default batching to false.

### DIFF
--- a/client.go
+++ b/client.go
@@ -788,7 +788,7 @@ func (e *DetachError) Error() string {
 // Default link options
 const (
 	DefaultLinkCredit      = 1
-	DefaultLinkBatching    = true
+	DefaultLinkBatching    = false
 	DefaultLinkBatchMaxAge = 5 * time.Second
 )
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -146,7 +146,6 @@ func TestIntegrationRoundTrip(t *testing.T) {
 					receiver, err := session.NewReceiver(
 						amqp.LinkSourceAddress(queueName),
 						amqp.LinkCredit(10),
-						amqp.LinkBatching(false),
 					)
 					if err != nil {
 						receiveErr = err
@@ -392,7 +391,6 @@ func TestIntegrationReceiverModeSecond(t *testing.T) {
 					receiver, err := session.NewReceiver(
 						amqp.LinkSourceAddress(queueName),
 						amqp.LinkReceiverSettle(amqp.ModeSecond),
-						amqp.LinkBatching(false),
 					)
 					if err != nil {
 						receiveErr = err
@@ -955,7 +953,6 @@ func createEventHubReceivers(t testing.TB, hubName string, session *amqp.Session
 			amqp.LinkSourceAddress(hubName+"/ConsumerGroups/$default/Partitions/"+strconv.Itoa(i)),
 			amqp.LinkSelectorFilter("amqp.annotation.x-opt-offset > '@latest'"),
 			amqp.LinkCredit(10),
-			amqp.LinkBatching(false),
 		)
 		if err != nil {
 			t.Fatalf("Error creating receiver: %v", err)


### PR DESCRIPTION
FEEDBACK REQUESTED: This changes a default behavior of the library. While this lib is still pre-1.0 and breaking changes should be expected, I don't make changes that could easily be missed by folks when upgrading lightly. In this case there will be no compiler errors to tip people off. That said, I think this is the correct thing to do. I would appreciate any feedback on the change and will leave this PR open for at least a couple days.

---

Batching has been enabled by default since the early days of this
library. In retrospect I think this was a mistake. I believe most users
would expect messages to be acknowledged immediately when calling
`Message.Accept()` (evidenced in #127). Requiring explicit opt-in
should lessen the risk of bugs due to the batching behavior.