### PR TITLE
Exposing LinkSourceFilter

### DIFF
--- a/client.go
+++ b/client.go
@@ -1506,19 +1506,24 @@ func LinkReceiverSettle(mode ReceiverSettleMode) LinkOption {
 
 // LinkSessionFilter sets a session filter (com.microsoft:session-filter) on the link source.
 // This is used in Azure Service Bus to filter messages by session ID on a receiving link.
+//
+// Deprecated: This option is now applied automatically by Azure/azure-service-bus-go
 func LinkSessionFilter(sessionID string) LinkOption {
 	// <descriptor name="com.microsoft:session-filter" code="00000013:7000000C"/>
-	return linkSourceFilter("com.microsoft:session-filter", uint64(0x00000137000000C), sessionID)
+	return LinkSourceFilter("com.microsoft:session-filter", uint64(0x00000137000000C), &sessionID)
 }
 
 // LinkSelectorFilter sets a selector filter (apache.org:selector-filter:string) on the link source.
 func LinkSelectorFilter(filter string) LinkOption {
 	// <descriptor name="apache.org:selector-filter:string" code="0x0000468C:0x00000004"/>
-	return linkSourceFilter("apache.org:selector-filter:string", uint64(0x0000468C00000004), filter)
+	return LinkSourceFilter("apache.org:selector-filter:string", uint64(0x0000468C00000004), &filter)
 }
 
-// linkSourceFilter sets a filter on the link source.
-func linkSourceFilter(name string, code uint64, value string) LinkOption {
+// LinkSourceFilter sets a filter on the link source.
+//
+// Largely this will be used by third-party packages which apply domain-specific message filtering on established links.
+// See amqp.LinkSessionFilter and amqp.LinkSelectorFilter for examples.
+func LinkSourceFilter(name string, code uint64, value *string) LinkOption {
 	nameSym := symbol(name)
 	return func(l *link) error {
 		if l.source == nil {
@@ -1527,10 +1532,18 @@ func linkSourceFilter(name string, code uint64, value string) LinkOption {
 		if l.source.Filter == nil {
 			l.source.Filter = make(map[symbol]*describedType)
 		}
-		l.source.Filter[nameSym] = &describedType{
+
+		describedValue := &describedType{
 			descriptor: code,
-			value:      value,
 		}
+
+		if value == nil {
+			describedValue.value = nil
+		} else {
+			describedValue.value = *value
+		}
+
+		l.source.Filter[nameSym] = describedValue
 		return nil
 	}
 }


### PR DESCRIPTION
Doing so will allow for third party link filtering options to be added in a more appropriate library.

Fixes #134 

This is an alternative to #135.