### PR TITLE
Fix settlement mode negotiation.

### DIFF
--- a/types.go
+++ b/types.go
@@ -2704,6 +2704,13 @@ func (m *SenderSettleMode) unmarshal(r *buffer) error {
 	return err
 }
 
+func (m *SenderSettleMode) value() SenderSettleMode {
+	if m == nil {
+		return ModeMixed
+	}
+	return *m
+}
+
 // Receiver Settlement Modes
 const (
 	// Receiver will spontaneously settle all incoming transfers.
@@ -2743,6 +2750,13 @@ func (m *ReceiverSettleMode) unmarshal(r *buffer) error {
 	n, err := readUbyte(r)
 	*m = ReceiverSettleMode(n)
 	return err
+}
+
+func (m *ReceiverSettleMode) value() ReceiverSettleMode {
+	if m == nil {
+		return ModeFirst
+	}
+	return *m
 }
 
 // Durability Policies


### PR DESCRIPTION
If application has not explicitly requested a settlement mode, any mode returned by the server is accepted.

If the application has explicitly requested a settlement mode and the server does not honor it an error is returned during link attachment.

While API compatible, the strict settlement mode check has the potential to break code. This will be tagged as v0.11.x to indicate that.

Updates #153 