### PR TITLE
Add write deadline to keepalive frame to avoid i/o timeout errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ cover.out
 .envrc
 recordings
 .vscode
+.idea

--- a/conn.go
+++ b/conn.go
@@ -559,6 +559,12 @@ func (c *conn) connReader() {
 func (c *conn) connWriter() {
 	defer close(c.txDone)
 
+	// disable write timeout
+	if c.connectTimeout != 0 {
+		c.connectTimeout = 0
+		_ = c.net.SetWriteDeadline(time.Time{})
+	}
+
 	var (
 		// keepalives are sent at a rate of 1/2 idle timeout
 		keepaliveInterval = c.peerIdleTimeout / 2
@@ -591,9 +597,6 @@ func (c *conn) connWriter() {
 
 		// keepalive timer
 		case <-keepalive:
-			if c.connectTimeout != 0 {
-				_ = c.net.SetWriteDeadline(time.Now().Add(c.connectTimeout))
-			}
 			_, err = c.net.Write(keepaliveFrame)
 			// It would be slightly more efficient in terms of network
 			// resources to reset the timer each time a frame is sent.

--- a/conn.go
+++ b/conn.go
@@ -591,6 +591,9 @@ func (c *conn) connWriter() {
 
 		// keepalive timer
 		case <-keepalive:
+			if c.connectTimeout != 0 {
+				_ = c.net.SetWriteDeadline(time.Now().Add(c.connectTimeout))
+			}
 			_, err = c.net.Write(keepaliveFrame)
 			// It would be slightly more efficient in terms of network
 			// resources to reset the timer each time a frame is sent.


### PR DESCRIPTION
Hi there, I found a bug in receiver role when connect timout is set (in my case to 5 seconds) and the keepalive frame is send. SetWriteDeadline() needs to be called before to avoid i/o timeout error.

12:37:20.823235 TX: Disposition{Role: Receiver, First: 63, Last: <nil>, Settled: true, State: Accepted, Batchable: false}
06/19 12:37:30.446 ERRO 174 receiver.go:137 - Reading message from AMQP: &net.OpError{Op:"write", Net:"tcp", Source:(*net.TCPAddr)(0xc420148780), Addr:(*net.TCPAddr)(0xc4201487b0), Err:(*poll.TimeoutError)(0x9e6de0)} write tcp 192.168.206.139:57124->93.174.217.56:5671: i/o timeout
