### PR TITLE
Fix settlement handling and add Message.SendSettled

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -1131,6 +1131,8 @@ func TestIssue48_ReceiverModeSecond(t *testing.T) {
 		// Create a sender
 		sender, err := session.NewSender(
 			amqp.LinkTargetAddress(hubName),
+			amqp.LinkSenderSettle(amqp.ModeUnsettled),
+			amqp.LinkReceiverSettle(amqp.ModeFirst),
 		)
 		if err != nil {
 			t.Fatalf("%+v\n", err)
@@ -1142,17 +1144,6 @@ func TestIssue48_ReceiverModeSecond(t *testing.T) {
 			Data: [][]byte{
 				[]byte("hello"),
 				[]byte("there"),
-			},
-		})
-		time.Sleep(1 * time.Second) // Have to wait long enough for disposition to come through.
-		if err != nil {
-			t.Fatalf("Unexpected error response: %+v", err)
-		}
-
-		// Second send should get async error
-		err = sender.Send(context.Background(), &amqp.Message{
-			Data: [][]byte{
-				[]byte("hello"),
 			},
 		})
 		if err == nil {

--- a/types.go
+++ b/types.go
@@ -1262,10 +1262,10 @@ type performTransfer struct {
 	Payload []byte
 
 	// optional channel to indicate to sender that transfer has completed
+	//
+	// Settled=true: closed when the transferred on network.
+	// Settled=false: closed when the receiver has confirmed settlement.
 	done chan deliveryState
-	// complete when receiver has responded with disposition (ReceiverSettleMode = second)
-	// instead of when this message has been sent on network
-	confirmSettlement bool
 }
 
 func (t *performTransfer) frameBody() {}
@@ -1726,6 +1726,11 @@ type Message struct {
 	// encryption details).
 	Footer Annotations
 
+	// Mark the message as settled when LinkSenderSettle is ModeMixed.
+	//
+	// This field is ignored when LinkSenderSettle is not ModeMixed.
+	SendSettled bool
+
 	receiver   *Receiver // Receiver the message was received from
 	deliveryID uint32    // used when sending disposition
 	settled    bool      // whether transfer was settled by sender
@@ -1810,7 +1815,7 @@ func (m *Message) MarshalBinary() ([]byte, error) {
 }
 
 func (m *Message) shouldSendDisposition() bool {
-	return !m.settled || (m.receiver.link.receiverSettleMode != nil && *m.receiver.link.receiverSettleMode == ModeSecond)
+	return !m.settled
 }
 
 func (m *Message) marshal(wr *buffer) error {


### PR DESCRIPTION
* `Message.SendSettled` allows sending messages settled when `LinkSenderSettle` is `ModeMixed`.

Fix for issues brought up in https://github.com/Azure/azure-event-hubs-go/pull/133