### PR TITLE
Fix Incorrect time calculation for dates before the Unix epoch

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -946,8 +946,8 @@ func readTimestamp(r *buffer) (time.Time, error) {
 	}
 
 	n, err := r.readUint64()
-	rem := n % 1000
-	return time.Unix(int64(n)/1000, int64(rem)*1000000).UTC(), err
+	ms := int64(n)
+	return time.Unix(ms/1000, (ms%1000)*1000000).UTC(), err
 }
 
 func readInt(r *buffer) (int, error) {

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -212,6 +212,24 @@ func TestMarshalUnmarshal(t *testing.T) {
 	}
 }
 
+// Regression test for time calculation bug.
+// https://github.com/vcabbage/amqp/issues/173
+func TestIssue173(t *testing.T) {
+	var buf buffer
+	// NOTE: Dates after the Unix Epoch don't trigger the bug, only
+	// dates that negative Unix time show the problem.
+	want := time.Date(1969, 03, 21, 0, 0, 0, 0, time.UTC)
+	err := marshal(&buf, want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got time.Time
+	err = unmarshal(&buf, &got)
+	if d := testDiff(want, got); d != "" {
+		t.Fatal(d)
+	}
+}
+
 func TestReadAny(t *testing.T) {
 	for _, type_ := range generalTypes {
 		t.Run(fmt.Sprintf("%T", type_), func(t *testing.T) {


### PR DESCRIPTION
AMQP timestamp is a signed value, but decoded from buffer as unsigned.
The previous code took the remainder of the unsigned value before
converting to signed which is incorrect for negative timestamps.

Fixes  #173