### PR TITLE
Fix Dial() host:port parsing to handle IPv6 literals.

### DIFF
--- a/local_test.go
+++ b/local_test.go
@@ -1,0 +1,37 @@
+// +build local
+
+package amqp_test
+
+import (
+	"net"
+	"testing"
+
+	"pack.ag/amqp"
+)
+
+// Tests that require a local broker running on the standard AMQP port.
+
+func TestDial_IPV6(t *testing.T) {
+	if c, err := amqp.Dial("amqp://localhost"); err != nil {
+		t.Skip("can't connect to local AMQP server")
+	} else {
+		c.Close()
+	}
+	l, err := net.Listen("tcp6", "[::]:0")
+	if err != nil {
+		t.Skip("ipv6 not supported")
+	}
+	l.Close()
+
+	for _, u := range []string{"amqp://[::]:5672", "amqp://[::]"} {
+		u := u // Don't  use range variable in func literal.
+		t.Run(u, func(t *testing.T) {
+			c, err := amqp.Dial(u)
+			if err != nil {
+				t.Errorf("%q: %v", u, err)
+			} else {
+				c.Close()
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #184

Signed-off-by: Alan Conway <aconway@redhat.com>