### PR TITLE
Channel 0 is a legal channel

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -370,7 +370,10 @@ func (c *conn) mux() {
 
 			// RemoteChannel should be used when frame is Begin
 			case *performBegin:
-				session, ok = sessionsByChannel[body.RemoteChannel]
+				if body.RemoteChannel == nil {
+					break
+				}
+				session, ok = sessionsByChannel[*body.RemoteChannel]
 				if !ok {
 					break
 				}

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -254,6 +254,8 @@ func TestReadAny(t *testing.T) {
 var (
 	allTypes = append(protoTypes, generalTypes...)
 
+	remoteChannel = uint16(4321)
+
 	protoTypes = []interface{}{
 		&performOpen{
 			ContainerID:         "foo",
@@ -269,7 +271,7 @@ var (
 			},
 		},
 		&performBegin{
-			RemoteChannel:       4321,
+			RemoteChannel:       &remoteChannel,
 			NextOutgoingID:      730000,
 			IncomingWindow:      9876654,
 			OutgoingWindow:      123555,

--- a/types.go
+++ b/types.go
@@ -265,7 +265,7 @@ type performBegin struct {
 	// If a session is locally initiated, the remote-channel MUST NOT be set.
 	// When an endpoint responds to a remotely initiated session, the remote-channel
 	// MUST be set to the channel on which the remote session sent the begin.
-	RemoteChannel uint16
+	RemoteChannel *uint16
 
 	// the transfer-id of the first transfer id the sender will send
 	NextOutgoingID uint32 // required, sequence number http://www.ietf.org/rfc/rfc1982.txt
@@ -301,10 +301,10 @@ type performBegin struct {
 func (b *performBegin) frameBody() {}
 
 func (b *performBegin) String() string {
-	return fmt.Sprintf("Begin{RemoteChannel: %d, NextOutgoingID: %d, IncomingWindow: %d, "+
+	return fmt.Sprintf("Begin{RemoteChannel: %v, NextOutgoingID: %d, IncomingWindow: %d, "+
 		"OutgoingWindow: %d, HandleMax: %d, OfferedCapabilities: %v, DesiredCapabilities: %v, "+
 		"Properties: %v}",
-		b.RemoteChannel,
+		formatUint16Ptr(b.RemoteChannel),
 		b.NextOutgoingID,
 		b.IncomingWindow,
 		b.OutgoingWindow,
@@ -315,9 +315,16 @@ func (b *performBegin) String() string {
 	)
 }
 
+func formatUint16Ptr(p *uint16) string {
+	if p == nil {
+		return "<nil>"
+	}
+	return strconv.FormatUint(uint64(*p), 10)
+}
+
 func (b *performBegin) marshal(wr *buffer) error {
 	return marshalComposite(wr, typeCodeBegin, []marshalField{
-		{value: &b.RemoteChannel, omit: b.RemoteChannel == 0},
+		{value: b.RemoteChannel, omit: b.RemoteChannel == nil},
 		{value: &b.NextOutgoingID, omit: false},
 		{value: &b.IncomingWindow, omit: false},
 		{value: &b.OutgoingWindow, omit: false},


### PR DESCRIPTION
It's not safe to use 0 as a null marker for performBegin.RemoteChannel, because
0 is a legal channel number. It works for a client-only library but is a problem
when adding server support.

Added a RemoteChannelMissing flag to distinguish the cases.

Signed-off-by: Alan Conway <aconway@redhat.com>