### PR TITLE
Rename Client to Conn

### DIFF
--- a/client.go
+++ b/client.go
@@ -27,10 +27,13 @@ var (
 	ErrLinkClosed = errors.New("amqp: link closed")
 )
 
-// Client is an AMQP client connection.
-type Client struct {
+// Conn is an AMQP client connection.
+type Conn struct {
 	conn *conn
 }
+
+// Client is a backwards-compatible alias for Conn
+type Client Conn
 
 // Dial connects to an AMQP server.
 //
@@ -39,7 +42,7 @@ type Client struct {
 //
 // If username and password information is not empty it's used as SASL PLAIN
 // credentials, equal to passing ConnSASLPlain option.
-func Dial(addr string, opts ...ConnOption) (*Client, error) {
+func Dial(addr string, opts ...ConnOption) (*Conn, error) {
 	u, err := url.Parse(addr)
 	if err != nil {
 		return nil, err
@@ -85,27 +88,27 @@ func Dial(addr string, opts ...ConnOption) (*Client, error) {
 		return nil, err
 	}
 	err = c.start()
-	return &Client{conn: c}, err
+	return &Conn{conn: c}, err
 }
 
 // New establishes an AMQP client connection over conn.
-func New(conn net.Conn, opts ...ConnOption) (*Client, error) {
+func New(conn net.Conn, opts ...ConnOption) (*Conn, error) {
 	c, err := newConn(conn, opts...)
 	if err != nil {
 		return nil, err
 	}
 	err = c.start()
-	return &Client{conn: c}, err
+	return &Conn{conn: c}, err
 }
 
 // Close disconnects the connection.
-func (c *Client) Close() error {
+func (c *Conn) Close() error {
 	return c.conn.Close()
 }
 
 // NewSession opens a new AMQP session to the server.
-func (c *Client) NewSession(opts ...SessionOption) (*Session, error) {
-	// get a session allocated by Client.mux
+func (c *Conn) NewSession(opts ...SessionOption) (*Session, error) {
+	// get a session allocated by Conn.mux
 	var sResp newSessionResp
 	select {
 	case <-c.conn.done:
@@ -251,7 +254,7 @@ func newSession(c *conn, channel uint16) *Session {
 // Close gracefully closes the session.
 //
 // If ctx expires while waiting for servers response, ctx.Err() will be returned.
-// The session will continue to wait for the response until the Client is closed.
+// The session will continue to wait for the response until the Conn is closed.
 func (s *Session) Close(ctx context.Context) error {
 	s.closeOnce.Do(func() { close(s.close) })
 	select {
@@ -1418,7 +1421,7 @@ func (l *link) muxHandleFrame(fr frameBody) error {
 // No operations on link are valid after close.
 //
 // If ctx expires while waiting for servers response, ctx.Err() will be returned.
-// The session will continue to wait for the response until the Session or Client
+// The session will continue to wait for the response until the Session or Conn
 // is closed.
 func (l *link) Close(ctx context.Context) error {
 	l.closeOnce.Do(func() { close(l.close) })
@@ -1898,7 +1901,7 @@ func (r *Receiver) Address() string {
 // Close closes the Receiver and AMQP link.
 //
 // If ctx expires while waiting for servers response, ctx.Err() will be returned.
-// The session will continue to wait for the response until the Session or Client
+// The session will continue to wait for the response until the Session or Conn
 // is closed.
 func (r *Receiver) Close(ctx context.Context) error {
 	return r.link.Close(ctx)

--- a/conn.go
+++ b/conn.go
@@ -23,7 +23,7 @@ var (
 	ErrTimeout = errors.New("amqp: timeout waiting for response")
 
 	// ErrConnClosed is propagated to Session and Senders/Receivers
-	// when Client.Close() is called or the server closes the connection
+	// when Conn.Close() is called or the server closes the connection
 	// without specifying an error.
 	ErrConnClosed = errors.New("amqp: connection closed")
 )
@@ -164,7 +164,7 @@ type conn struct {
 	// TLS
 	tlsNegotiation bool        // negotiate TLS
 	tlsComplete    bool        // TLS negotiation complete
-	tlsConfig      *tls.Config // TLS config, default used if nil (ServerName set to Client.hostname)
+	tlsConfig      *tls.Config // TLS config, default used if nil (ServerName set to Conn.hostname)
 
 	// SASL
 	saslHandlers map[symbol]stateFunc // map of supported handlers keyed by SASL mechanism, SASL not negotiated if nil
@@ -756,7 +756,7 @@ func (c *conn) readProtoHeader() (protoHeader, error) {
 	}
 }
 
-// startTLS wraps the conn with TLS and returns to Client.negotiateProto
+// startTLS wraps the conn with TLS and returns to Conn.negotiateProto
 func (c *conn) startTLS() stateFunc {
 	c.initTLSConfig()
 
@@ -871,7 +871,7 @@ func (c *conn) negotiateSASL() stateFunc {
 	return nil
 }
 
-// saslOutcome processes the SASL outcome frame and return Client.negotiateProto
+// saslOutcome processes the SASL outcome frame and return Conn.negotiateProto
 // on success.
 //
 // SASL handlers return this stateFunc when the mechanism specific negotiation

--- a/integration_test.go
+++ b/integration_test.go
@@ -1208,17 +1208,17 @@ func dump(i interface{}) {
 	enc.Encode(i)
 }
 
-func newEHClient(t testing.TB, label string, opts ...amqp.ConnOption) *amqp.Client {
+func newEHClient(t testing.TB, label string, opts ...amqp.ConnOption) *amqp.Conn {
 	t.Helper()
 	return newClient(t, label, ehNamespace, ehAccessKeyName, ehAccessKey, opts...)
 }
 
-func newSBClient(t testing.TB, label string, opts ...amqp.ConnOption) *amqp.Client {
+func newSBClient(t testing.TB, label string, opts ...amqp.ConnOption) *amqp.Conn {
 	t.Helper()
 	return newClient(t, label, namespace, accessKeyName, accessKey, opts...)
 }
 
-func newClient(t testing.TB, label, ns, username, password string, opts ...amqp.ConnOption) *amqp.Client {
+func newClient(t testing.TB, label, ns, username, password string, opts ...amqp.ConnOption) *amqp.Conn {
 	t.Helper()
 
 	opts = append(opts,


### PR DESCRIPTION
Renamed Client to Conn, with alias type so backward compatible.
Did not rename client.go due to clash with existing conn.go.

Signed-off-by: Alan Conway <aconway@redhat.com>