### PR TITLE
Improved debug logging.

### DIFF
--- a/log.go
+++ b/log.go
@@ -4,4 +4,5 @@ package amqp
 
 // dummy functions used when debugging is not enabled
 
-func debug(_ int, _ string, _ ...interface{}) {}
+func debug(_ int, _ string, _ ...interface{})      {}
+func debugFrame(c *conn, prefix string, fr *frame) {}

--- a/log_debug.go
+++ b/log_debug.go
@@ -25,3 +25,20 @@ func debug(level int, format string, v ...interface{}) {
 		logger.Printf(format, v...)
 	}
 }
+
+func debugFrame(c *conn, prefix string, fr *frame) {
+	if debugLevel == 0 { // Fast exit for no logging
+		return
+	}
+	// Set level by frame type
+	level := 1 // Normal frames at 1
+	switch fr.body.(type) {
+	case *performTransfer: // High-volume messages
+		level = 2
+	case *performFlow, *performDisposition: // Noisy flow and acknowledgment
+		level = 3
+	}
+	if level <= debugLevel {
+		logger.Printf("%p %s[%d]: %s", c, prefix, fr.channel, fr.body)
+	}
+}

--- a/sasl.go
+++ b/sasl.go
@@ -47,7 +47,6 @@ func ConnSASLPlain(username, password string) ConnOption {
 				InitialResponse: []byte("\x00" + username + "\x00" + password),
 				Hostname:        "",
 			}
-			debug(1, "TX: %s", init)
 			c.err = c.writeFrame(frame{
 				type_: frameTypeSASL,
 				body:  init,
@@ -77,7 +76,6 @@ func ConnSASLAnonymous() ConnOption {
 				Mechanism:       saslMechanismANONYMOUS,
 				InitialResponse: []byte("anonymous"),
 			}
-			debug(1, "TX: %s", init)
 			c.err = c.writeFrame(frame{
 				type_: frameTypeSASL,
 				body:  init,


### PR DESCRIPTION
Added connection id (pointer) and channel for debugging multi-connection/session programs.

Centralized scattered debug logic to fix missing/duplicate log entries.

Removed (Session) and (Link) decorations - these can be deduced from the frame type.

Don't print null fields in log output - reduce distracting clutter.

Signed-off-by: Alan Conway <aconway@redhat.com>